### PR TITLE
feat(p0): scripts/ skeletons + EnvVarManifest + deployment-settings template/schema

### DIFF
--- a/scripts/deployment-settings.json.template
+++ b/scripts/deployment-settings.json.template
@@ -1,0 +1,91 @@
+{
+  "$schema": "./deployment-settings.schema.json",
+  "_comment": "HLS Power Platform Demo deployment settings template. Copy this file to scripts/deployment-settings.json (gitignored) and fill in the values for your demo environment. install.ps1 reads from this file. Per Topic 4: only operator-input values live here; provisioned-by-install URLs/IDs (Pages/Code App URL, Teams team/channel IDs, SharePoint library, agent IDs, Entra app reg IDs) are written back to this file by install.ps1 after the relevant resource is created.",
+
+  "environment": {
+    "_comment": "Power Platform environment to target. Get the URL from `pac env list`. The environment must already exist; install.ps1 does not create environments (operator's tenant decision).",
+    "name": "<set-me: friendly env name, e.g. Continuum Demo (Dev)>",
+    "url": "<set-me: https://orgxxxx.crm.dynamics.com>",
+    "region": "unitedstates"
+  },
+
+  "superUsers": [
+    "<set-me: primary super user UPN, e.g. operator@contoso.onmicrosoft.com>"
+  ],
+
+  "tenant": {
+    "_comment": "Tenant to provision Entra app registrations + SharePoint site + Teams team in (Lead PR #2 per Topic 11 §A3).",
+    "id": "<set-me: tenant GUID>",
+    "domain": "<set-me: tenant.onmicrosoft.com>"
+  },
+
+  "urls": {
+    "_comment": "URLs of provisioned resources. Most are populated by install.ps1 after the resource exists; you only set cch_UrlSharePointSite (operator picks the SP site to host knowledge docs).",
+    "cch_UrlSharePointSite": "<set-me: https://contoso.sharepoint.com/sites/continuum-demo>",
+    "cch_UrlPagesSite": null,
+    "cch_UrlCodeApp": null,
+    "cch_UrlTeamsTenant": null,
+    "cch_UrlGraphBase": null
+  },
+
+  "ids": {
+    "_comment": "GUIDs of provisioned resources. All populated by install.ps1; leave null at first install.",
+    "cch_IdTeamsTeam": null,
+    "cch_IdTeamsChannelQuality": null,
+    "cch_IdTeamsChannelLeadership": null,
+    "cch_IdTeamsChannelField": null,
+    "cch_IdTeamsChannelEnablement": null,
+    "cch_IdSharePointLibraryKnowledge": null,
+    "cch_IdAgentPatientSupport": null,
+    "cch_IdAgentQualityTriage": null,
+    "cch_IdAgentEnablement": null,
+    "cch_IdEntraAppPagesAuth": null,
+    "cch_IdEntraAppServicePrincipal": null,
+    "cch_IdPipelinesHostEnv": null
+  },
+
+  "secrets": {
+    "_comment": "Per Topic 4 SecretRef abstraction: each value is `plain:<value>` for development or `kv:<keyVault>/<secret>[?version=<v>]` for Key Vault-backed (future). Doctor flags plain:* as info-level to remind operator. Direct Line secrets come from Copilot Studio channel config; Graph + SP client secrets come from Setup-ServicePrincipal.ps1 (Lead PR #2).",
+    "cch_SecretDirectLinePatientSupport": "plain:<set-me-after-publishing-agent>",
+    "cch_SecretDirectLineQualityTriage": "plain:<set-me-after-publishing-agent>",
+    "cch_SecretDirectLineEnablement": "plain:<set-me-after-publishing-agent>",
+    "cch_SecretGraphAppClient": "plain:<set-me-after-Setup-ServicePrincipal>",
+    "cch_SecretSPClient": "plain:<set-me-after-Setup-ServicePrincipal>"
+  },
+
+  "tunables": {
+    "_comment": "Optional behavior overrides. Defaults from EnvVarManifest.json apply if you leave a value null.",
+    "cch_TunableLiveSimCron": null,
+    "cch_TunableDemoRefreshCron": null,
+    "cch_TunableMdrClockHours": null,
+    "cch_TunableShipmentStepSeconds": null,
+    "cch_TunableTimezone": null
+  },
+
+  "featureFlags": {
+    "_comment": "All vignette + infrastructure flags default true. Set to false to skip a vignette in this env (e.g., demoing only V1+V4+V6 highlight reel).",
+    "cch_FeatureV1PatientPortal": null,
+    "cch_FeatureV2HCPPortal": null,
+    "cch_FeatureV3FieldCompanion": null,
+    "cch_FeatureV4QualityTriage": null,
+    "cch_FeatureV5EnablementKnowledge": null,
+    "cch_FeatureV6ExtendEverywhere": null,
+    "cch_FeatureLiveSim": null,
+    "cch_FeatureDailyRefresh": null,
+    "cch_FeatureDemoModeBanner": null
+  },
+
+  "brand": {
+    "_comment": "Optional brand string overrides. Defaults from EnvVarManifest.json apply if null. Useful if you fork this template for a different fictional company without restructuring the planning corpus.",
+    "cch_BrandCompanyName": null,
+    "cch_BrandPrimaryColor": null,
+    "cch_BrandFooterDisclaimer": null,
+    "cch_BrandDemoModeBannerText": null
+  },
+
+  "connections": {
+    "_comment": "Per-connection-reference owner override per Topic 3 §3.7 hybrid pattern. Default for each ref is set in install.ps1 (SP via Graph for most; interactive identity for personal-mailbox/calendar/Teams-1:1/OneDrive-personal). Use this map only when you want to override a default.",
+    "_format": "{ \"<connection-reference-logical-name>\": \"sp\" | \"interactive\" }",
+    "_example": { "cch_OutlookSendAsMe": "interactive" }
+  }
+}

--- a/scripts/deployment-settings.schema.json
+++ b/scripts/deployment-settings.schema.json
@@ -1,0 +1,379 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/PhillyUrbs/HLS-PowerPlatform-Demo/scripts/deployment-settings.schema.json",
+    "title": "HLS Power Platform Demo — deployment-settings.json",
+    "description": "Operator-edited file consumed by install.ps1 / upgrade.ps1. The actual file (scripts/deployment-settings.json) is gitignored; the template (deployment-settings.json.template) is committed. Per Topic 4: categorized object with one top-level key per env-var category + superUsers array + connections override map.",
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+        "environment",
+        "superUsers",
+        "tenant",
+        "urls",
+        "ids",
+        "secrets"
+    ],
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "_comment": {
+            "type": "string"
+        },
+        "environment": {
+            "type": "object",
+            "required": [
+                "name",
+                "url"
+            ],
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "url": {
+                    "type": "string",
+                    "pattern": "^https://.+\\.(crm[0-9]*\\.dynamics\\.com|dynamics\\.com)/?$",
+                    "description": "Dataverse environment URL (e.g. https://orgxxxx.crm.dynamics.com)."
+                },
+                "region": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "superUsers": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "format": "email",
+                "description": "Demo super user UPN. Per locked Flavor-A: array of equals; install.ps1 assigns the same security roles to each."
+            }
+        },
+        "tenant": {
+            "type": "object",
+            "required": [
+                "id",
+                "domain"
+            ],
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$|^<set-me:.+>$"
+                },
+                "domain": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "urls": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_UrlSharePointSite": {
+                    "$ref": "#/$defs/urlOrPlaceholder"
+                },
+                "cch_UrlPagesSite": {
+                    "$ref": "#/$defs/urlOrNull"
+                },
+                "cch_UrlCodeApp": {
+                    "$ref": "#/$defs/urlOrNull"
+                },
+                "cch_UrlTeamsTenant": {
+                    "$ref": "#/$defs/urlOrNull"
+                },
+                "cch_UrlGraphBase": {
+                    "$ref": "#/$defs/urlOrNull"
+                }
+            },
+            "required": [
+                "cch_UrlSharePointSite"
+            ],
+            "additionalProperties": false
+        },
+        "ids": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_IdTeamsTeam": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdTeamsChannelQuality": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdTeamsChannelLeadership": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdTeamsChannelField": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdTeamsChannelEnablement": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdSharePointLibraryKnowledge": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdAgentPatientSupport": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdAgentQualityTriage": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdAgentEnablement": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdEntraAppPagesAuth": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdEntraAppServicePrincipal": {
+                    "$ref": "#/$defs/guidOrNull"
+                },
+                "cch_IdPipelinesHostEnv": {
+                    "$ref": "#/$defs/guidOrNull"
+                }
+            },
+            "additionalProperties": false
+        },
+        "secrets": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_SecretDirectLinePatientSupport": {
+                    "$ref": "#/$defs/secretRef"
+                },
+                "cch_SecretDirectLineQualityTriage": {
+                    "$ref": "#/$defs/secretRef"
+                },
+                "cch_SecretDirectLineEnablement": {
+                    "$ref": "#/$defs/secretRef"
+                },
+                "cch_SecretGraphAppClient": {
+                    "$ref": "#/$defs/secretRef"
+                },
+                "cch_SecretSPClient": {
+                    "$ref": "#/$defs/secretRef"
+                }
+            },
+            "required": [
+                "cch_SecretDirectLinePatientSupport",
+                "cch_SecretDirectLineQualityTriage",
+                "cch_SecretDirectLineEnablement",
+                "cch_SecretGraphAppClient",
+                "cch_SecretSPClient"
+            ],
+            "additionalProperties": false
+        },
+        "tunables": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_TunableLiveSimCron": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cch_TunableDemoRefreshCron": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cch_TunableMdrClockHours": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 1
+                },
+                "cch_TunableShipmentStepSeconds": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 1
+                },
+                "cch_TunableTimezone": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "featureFlags": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_FeatureV1PatientPortal": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureV2HCPPortal": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureV3FieldCompanion": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureV4QualityTriage": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureV5EnablementKnowledge": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureV6ExtendEverywhere": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureLiveSim": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureDailyRefresh": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "cch_FeatureDemoModeBanner": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "brand": {
+            "type": "object",
+            "properties": {
+                "_comment": {
+                    "type": "string"
+                },
+                "cch_BrandCompanyName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cch_BrandPrimaryColor": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "pattern": "^#[0-9A-Fa-f]{6}$|^null$"
+                },
+                "cch_BrandFooterDisclaimer": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "cch_BrandDemoModeBannerText": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "connections": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "enum": [
+                    "sp",
+                    "interactive"
+                ],
+                "description": "Per-connection-reference owner override per Topic 3 §3.7 hybrid pattern."
+            }
+        }
+    },
+    "$defs": {
+        "urlOrPlaceholder": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^https://.+"
+                },
+                {
+                    "type": "string",
+                    "pattern": "^<set-me:.+>$"
+                }
+            ]
+        },
+        "urlOrNull": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^https?://.+"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "guidOrNull": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "secretRef": {
+            "type": "string",
+            "oneOf": [
+                {
+                    "pattern": "^plain:.+",
+                    "description": "Development mode: plain:<value>. Doctor flags as info-level finding."
+                },
+                {
+                    "pattern": "^kv:[^/]+/[^?]+(\\?version=.+)?$",
+                    "description": "Key Vault mode: kv:<keyVault>/<secret>[?version=<v>]. Resolved via Resolve-Secret in scripts/lib/Secrets.ps1 or cch_ResolveSecret child flow at runtime."
+                }
+            ]
+        }
+    }
+}

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -1,0 +1,346 @@
+<#
+.SYNOPSIS
+    Read-only health check for the HLS Power Platform Demo. Reports posture without changing data.
+
+.DESCRIPTION
+    Per Topic 11 section C3 (Phase 0 multi-sitting), this is a **skeleton**: every section
+    emits a single `[NotImplemented]` finding so the JSON output schema (Topic 11
+    pin) is exercised end-to-end + the runner can already use --vignette / --mode flags.
+
+    Real check implementations land in subsequent sittings/phases (typically as the
+    surface they audit ships). Doctor is read-only and never mutates regardless of
+    flags (locked Topic 5 + Topic 6 + Topic 8B + Topic 10 doctor rules).
+
+.PARAMETER Vignette
+    Subset to one vignette's pre-flight check set: V1 | V2 | V3 | V4 | V5 | V6.
+    Used by Demo Health pre-flight buttons (Topic 9 + 9B).
+
+.PARAMETER Mode
+    full      Default. Run all sections.
+    chained   Run union of all 6 vignette pre-flights + bridge-state checks.
+    highlight Run V1 + V4 + V6 pre-flights only (highlight reel).
+
+.PARAMETER Json
+    Emit JSON to stdout (per Topic 11 doctor JSON output schema). Default: human-
+    readable.
+
+.PARAMETER Section
+    Filter to a single section: Permissions | EnvVars | Governance | Telemetry |
+    A11y | Knowledge | Squad | Agents.
+
+.EXAMPLE
+    pwsh ./scripts/doctor.ps1
+    Full read-only health check, human output.
+
+.EXAMPLE
+    pwsh ./scripts/doctor.ps1 --vignette V4 --json
+    Pre-flight check for V4 only, JSON output (consumed by Demo Health 'Pre-flight V4' button).
+
+.NOTES
+    Owner role: Tester (per scripts/AGENTS.md).
+    Topic refs: Topic 11 (doctor JSON output schema pin), Topic 5 (Governance section),
+                Topic 6 (Telemetry section), Topic 7 (A11y section), Topic 8B (Knowledge
+                section), Topic 10 (Squad section), Topic 9 + 9B (vignette modes).
+    Required PowerShell: 7+.
+    Exit codes:
+      0   all checks pass or info/warn only
+      1   one or more checks errored (severity = error)
+      2   doctor itself errored (cannot read phase.json, cannot reach env, etc.)
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [ValidateSet('V1', 'V2', 'V3', 'V4', 'V5', 'V6')]
+    [string] $Vignette,
+
+    [ValidateSet('full', 'chained', 'highlight')]
+    [string] $Mode = 'full',
+
+    [switch] $Json,
+
+    [ValidateSet('Permissions', 'EnvVars', 'Governance', 'Telemetry', 'A11y', 'Knowledge', 'Squad', 'Agents')]
+    [string] $Section = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ─── Locate repo root ───────────────────────────────────────────────────────
+$repoRoot = (git rev-parse --show-toplevel 2>$null)
+if (-not $repoRoot) { Write-Error "doctor.ps1: not inside a git repo."; exit 2 }
+$repoRoot = $repoRoot.Trim()
+
+# ─── Run identity (per Topic 11 doctor JSON schema) ─────────────────────────
+$runId  = [guid]::NewGuid().ToString()
+$ranAt  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+$result = [pscustomobject]@{
+    version  = '1.0'
+    runId    = $runId
+    ranAt    = $ranAt
+    vignette = $Vignette
+    mode     = $Mode
+    sections = @()
+}
+
+# ─── Helper: add a finding to a section ─────────────────────────────────────
+function New-Finding {
+    param(
+        [Parameter(Mandatory)] [string] $Id,
+        [Parameter(Mandatory)] [ValidateSet('pass', 'info', 'warn', 'error')] [string] $Severity,
+        [Parameter(Mandatory)] [string] $Title,
+        [string] $Detail,
+        [string] $DeepLink
+    )
+    [pscustomobject]@{
+        id       = $Id
+        severity = $Severity
+        title    = $Title
+        detail   = $Detail
+        deepLink = $DeepLink
+    }
+}
+
+function Add-Section {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [array]  $Findings
+    )
+    $script:result.sections += [pscustomobject]@{
+        name     = $Name
+        findings = $Findings
+    }
+}
+
+# ─── Section runners (skeletons) ────────────────────────────────────────────
+
+function Get-Section_Permissions {
+    @(
+        New-Finding -Id 'permissions.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] Permissions section' `
+            -Detail 'TODO Pages-Engineer + Governance: wire audit-permissions skill output here. See Topic 3 + Topic 8B knowledge ACL extension.'
+    )
+}
+
+function Get-Section_EnvVars {
+    # Real check (we have what we need today): parse EnvVarManifest.json + verify
+    # naming pattern. Full env-var validation against deployed Dataverse is Phase 1+.
+    $findings = @()
+    $manifestPath = Join-Path $repoRoot 'scripts/lib/EnvVarManifest.json'
+    if (-not (Test-Path $manifestPath)) {
+        $findings += New-Finding -Id 'envvars.manifest.missing' -Severity 'error' `
+            -Title 'EnvVarManifest.json missing' `
+            -Detail "Expected at $manifestPath"
+    } else {
+        try {
+            $m = Get-Content $manifestPath -Raw | ConvertFrom-Json
+            $count = $m.variables.Count
+            $required = @($m.variables | Where-Object { $_.required }).Count
+            $findings += New-Finding -Id 'envvars.manifest.parsed' -Severity 'pass' `
+                -Title "EnvVarManifest.json parsed ($count vars, $required required)"
+
+            # Naming pattern check
+            $bad = @($m.variables | Where-Object { $_.name -notmatch '^cch_(Url|Id|Secret|Tunable|Feature|Brand)[A-Z][A-Za-z0-9]*$' })
+            if ($bad.Count -gt 0) {
+                $findings += New-Finding -Id 'envvars.naming.malformed' -Severity 'error' `
+                    -Title "$($bad.Count) env var(s) violate cch_<Category><Name> convention" `
+                    -Detail (($bad | ForEach-Object { $_.name }) -join ', ')
+            } else {
+                $findings += New-Finding -Id 'envvars.naming.clean' -Severity 'pass' `
+                    -Title "All env var names match cch_<Category><Name>"
+            }
+        } catch {
+            $findings += New-Finding -Id 'envvars.manifest.parse-fail' -Severity 'error' `
+                -Title 'EnvVarManifest.json failed to parse' `
+                -Detail $_.Exception.Message
+        }
+    }
+
+    # TODO Tester (Phase 1+): once a target Dataverse env exists,
+    #   - Load deployed cch_* env vars
+    #   - Cross-reference against manifest (missing-required → upgrade prompt)
+    #   - URL env vars must start with https:// + no localhost / 127.0.0.1
+    #   - GUID env vars match GUID regex
+    #   - Secret env vars: non-empty + format-valid via Test-SecretReference;
+    #     plain:* emits info-level "consider KV" finding
+    #   - Cron tunables parse (Cronos)
+    #   - Boolean feature flags must be 'true' or 'false'
+    $findings += New-Finding -Id 'envvars.deployed.not-yet-checked' -Severity 'info' `
+        -Title '[NotImplemented] Deployed Dataverse env-var check' `
+        -Detail 'Lands in Phase 1+ once a target env exists.'
+
+    $findings
+}
+
+function Get-Section_Governance {
+    @(
+        New-Finding -Id 'governance.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] Governance section' `
+            -Detail 'TODO Governance (Sitting 5): report DLP applied, ME enabled, audit at 3 layers, Pipelines host present, CoE installed (info-only). See Topic 5 Doctor coverage.'
+    )
+}
+
+function Get-Section_Telemetry {
+    @(
+        New-Finding -Id 'telemetry.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] Telemetry section' `
+            -Detail 'TODO Tester (Phase 4): cch_TelemetryEvent row count, errors last 24h, agent tool-call success rate, flow success rate, oldest event > retention, cch_LogTelemetry enabled, payload schema-drift. See Topic 6 Doctor.'
+    )
+}
+
+function Get-Section_A11y {
+    @(
+        New-Finding -Id 'a11y.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] A11y section' `
+            -Detail 'TODO Tester: read last CI run summary; report a11y status as info only (Topic 7).'
+    )
+}
+
+function Get-Section_Knowledge {
+    @(
+        New-Finding -Id 'knowledge.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] Knowledge section' `
+            -Detail 'TODO Scribe + Tester (Phase 1+): SharePoint library exists, 4 subfolders present, 15 docs match inventory, lastReviewed freshness < 8d, ACLs match spec. See Topic 8B Doctor Knowledge.'
+    )
+}
+
+function Get-Section_Squad {
+    # Real check today: phase.json validity + AGENTS.md presence + decisions.md staleness
+    $findings = @()
+
+    $phasePath = Join-Path $repoRoot '.squad/phase.json'
+    if (-not (Test-Path $phasePath)) {
+        $findings += New-Finding -Id 'squad.phase-json.missing' -Severity 'error' `
+            -Title '.squad/phase.json missing'
+    } else {
+        try {
+            $p = Get-Content $phasePath -Raw | ConvertFrom-Json
+            $required = @('currentPhase','currentPhaseName','phaseStartedAt','allowedFolders','warningFolders','completionChecklist')
+            $missing = @($required | Where-Object { -not $p.PSObject.Properties.Name.Contains($_) })
+            if ($missing.Count -gt 0) {
+                $findings += New-Finding -Id 'squad.phase-json.shape' -Severity 'error' `
+                    -Title 'phase.json missing required keys' -Detail ($missing -join ', ')
+            } else {
+                $findings += New-Finding -Id 'squad.phase-json.ok' -Severity 'pass' `
+                    -Title "phase.json valid (currentPhase=$($p.currentPhase) — $($p.currentPhaseName))"
+            }
+        } catch {
+            $findings += New-Finding -Id 'squad.phase-json.parse-fail' -Severity 'error' `
+                -Title 'phase.json failed to parse' -Detail $_.Exception.Message
+        }
+    }
+
+    # AGENTS.md presence (root + 7 subfolders)
+    $required = @(
+        'AGENTS.md',
+        'solutions/ContinuumHealthDemo/AGENTS.md',
+        'apps/field-companion/AGENTS.md',
+        'sites/continuum-portal/AGENTS.md',
+        'agents/AGENTS.md',
+        'scripts/AGENTS.md',
+        'data/AGENTS.md',
+        'docs/AGENTS.md'
+    )
+    $missing = @($required | Where-Object { -not (Test-Path (Join-Path $repoRoot $_)) })
+    if ($missing.Count -gt 0) {
+        $findings += New-Finding -Id 'squad.agents-md.missing' -Severity 'warn' `
+            -Title "$($missing.Count) AGENTS.md file(s) missing" -Detail ($missing -join ', ')
+    } else {
+        $findings += New-Finding -Id 'squad.agents-md.ok' -Severity 'pass' `
+            -Title 'All 8 AGENTS.md files present (root + 7 subfolders)'
+    }
+
+    # decisions.md freshness
+    $decPath = Join-Path $repoRoot '.squad/decisions.md'
+    if (Test-Path $decPath) {
+        $age = (Get-Date) - (Get-Item $decPath).LastWriteTime
+        if ($age.TotalDays -gt 30) {
+            $findings += New-Finding -Id 'squad.decisions.stale' -Severity 'warn' `
+                -Title "decisions.md last updated $([math]::Round($age.TotalDays)) days ago" `
+                -Detail 'May indicate drift if commits have landed in this period.'
+        } else {
+            $findings += New-Finding -Id 'squad.decisions.fresh' -Severity 'pass' `
+                -Title "decisions.md last updated $([math]::Round($age.TotalDays)) day(s) ago"
+        }
+    }
+
+    $findings
+}
+
+function Get-Section_Agents {
+    @(
+        New-Finding -Id 'agents.skeleton' -Severity 'info' `
+            -Title '[NotImplemented] Agents section' `
+            -Detail 'TODO Agent-Builder + Tester (Phase 5): m365-readiness.md exists, all 6 checklist boxes checked, agents/employee-enablement/icons/ present. See Topic 8C M365 readiness.'
+    )
+}
+
+# ─── Run sections ───────────────────────────────────────────────────────────
+
+# Section selection logic (Section filter trumps Vignette/Mode)
+$sectionsToRun = if ($Section) {
+    @($Section)
+} elseif ($Vignette) {
+    # Vignette mode: minimal subset
+    # TODO Tester (Sitting 4 follow-up + Phase 3+): per-vignette section subset per Topic 9B.
+    # For now, run all sections so the runner is exercised end-to-end.
+    @('Permissions','EnvVars','Governance','Telemetry','A11y','Knowledge','Squad','Agents')
+} else {
+    @('Permissions','EnvVars','Governance','Telemetry','A11y','Knowledge','Squad','Agents')
+}
+
+foreach ($sectionName in $sectionsToRun) {
+    $fn = "Get-Section_$sectionName"
+    $findings = & $fn
+    Add-Section -Name $sectionName -Findings $findings
+}
+
+# ─── Output ─────────────────────────────────────────────────────────────────
+
+if ($Json) {
+    # -Compress emits single-line JSON which avoids embedded CR/LF in strings on Windows
+    # (Python's strict JSON parser rejects bare \r in string values).
+    $result | ConvertTo-Json -Depth 10 -Compress
+} else {
+    Write-Host ""
+    Write-Host "─── doctor.ps1 — read-only health check ───────────────────────────────" -ForegroundColor Cyan
+    $vignetteLabel = if ($Vignette) { " [$Vignette]" } else { '' }
+    Write-Host "  Run:    $runId" -ForegroundColor DarkGray
+    Write-Host "  Mode:   $Mode$vignetteLabel" -ForegroundColor DarkGray
+    Write-Host "────────────────────────────────────────────────────────────────────────" -ForegroundColor Cyan
+
+    foreach ($sectionResult in $result.sections) {
+        Write-Host ""
+        Write-Host "[$($sectionResult.name)]" -ForegroundColor Cyan
+        foreach ($f in $sectionResult.findings) {
+            $color = switch ($f.severity) {
+                'pass'  { 'Green' }
+                'info'  { 'DarkGray' }
+                'warn'  { 'Yellow' }
+                'error' { 'Red' }
+            }
+            $marker = switch ($f.severity) {
+                'pass'  { '  pass ' }
+                'info'  { '  info ' }
+                'warn'  { '  warn ' }
+                'error' { '  ERR  ' }
+            }
+            Write-Host "$marker $($f.title)" -ForegroundColor $color
+            if ($f.detail) {
+                Write-Host "         $($f.detail)" -ForegroundColor DarkGray
+            }
+        }
+    }
+    Write-Host ""
+}
+
+# Exit 1 if any error-severity finding exists
+$errors = @($result.sections | ForEach-Object { $_.findings | Where-Object { $_.severity -eq 'error' } })
+if ($errors.Count -gt 0) {
+    if (-not $Json) {
+        Write-Host "doctor: $($errors.Count) error-level finding(s)." -ForegroundColor Red
+    }
+    exit 1
+}
+exit 0

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,251 @@
+<#
+.SYNOPSIS
+    Lifecycle entry point for the HLS Power Platform Demo (install / upgrade / uninstall / doctor / seed / refresh-dates).
+
+.DESCRIPTION
+    Per Topic 11 §C3 (Phase 0 lands in multiple sittings), this script is currently a
+    **skeleton**: every mode parses arguments, validates deployment-settings.json against
+    its schema, then exits with a structured "[NotImplemented]" message and exit code 99.
+
+    Real implementations land in subsequent sittings (Sitting 4g for Lead PR #2 = Entra
+    app reg provisioning; later sittings for solution import, env var population, smoke,
+    etc.).
+
+    The script is invoked directly OR via the thin entry-point wrappers (upgrade.ps1,
+    uninstall.ps1) which forward to install.ps1 with the appropriate -Mode.
+
+.PARAMETER Mode
+    install         First-time provision: env vars, Entra app regs, SharePoint, Teams,
+                    solution import, seed data. Once per env.
+    upgrade         Default in CI. Solution upsert, code app push, Pages re-publish,
+                    agent re-publish, schema migrations, idempotent re-provision,
+                    insert-only seed updates by default.
+    uninstall       Manual + interactive. Default scope: solution + Entra apps +
+                    SharePoint site + Teams team. Does NOT default to demo super user
+                    delete or DLP/ME removal. --yes-to-all flag (TODO) for scripted use.
+    doctor          Read-only health check across 7 sections (Permissions, EnvVars,
+                    Governance, Telemetry, A11y, Knowledge, Squad). Reports drift;
+                    never changes data. Delegates to scripts/doctor.ps1.
+    seed            Re-seed Dataverse with synthetic data. Use --reseed to wipe + reseed
+                    (default is insert-net-new only).
+    refresh-dates   Run the cch_TunableDemoRefreshCron logic on demand (slides every
+                    time-sensitive field forward by elapsed delta).
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+    Override with -DeploymentSettingsPath or env var DEPLOYMENT_SETTINGS_PATH.
+
+.PARAMETER Apply
+    Mutate. Default is --whatif (preview only). Per locked Topic 5 + scripts/AGENTS.md
+    house rule, every state-changing operation requires explicit -Apply.
+
+.PARAMETER NonInteractive
+    Skip all operator prompts (CI / scripted use). Will fail fast if any required env
+    var is missing rather than prompting.
+
+.PARAMETER LogLevel
+    info (default) | debug | trace. Override with env var LOG_LEVEL.
+
+.EXAMPLE
+    pwsh ./scripts/install.ps1 -Mode install
+
+    Preview install (--whatif default). Validates deployment-settings.json shape, prompts
+    for any missing required env vars, prints the action plan, exits without mutating.
+
+.EXAMPLE
+    pwsh ./scripts/install.ps1 -Mode upgrade -Apply -NonInteractive
+
+    Default mode in CI. Detects new required env vars added since last deploy, runs
+    pending migrations, re-imports solution, refreshes Code App + Pages.
+
+.EXAMPLE
+    pwsh ./scripts/install.ps1 -Mode doctor
+
+    Runs scripts/doctor.ps1 (read-only; no mutation regardless of -Apply flag).
+
+.NOTES
+    Owner role: Lead (per scripts/AGENTS.md).
+    Topic refs: Topic 4 (env vars), Topic 5 (governance scripts emitted but not run),
+                Topic 11 §A3 (Entra provisioning is Lead PR #2 = Sitting 4g).
+    Required PowerShell: 7+.
+    Exit codes:
+      0   success
+      1   user-facing error (validation failed, missing required env var, etc.)
+      2   environment error (target env unreachable, auth failure, etc.)
+      99  not yet implemented (this skeleton)
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('install', 'upgrade', 'uninstall', 'doctor', 'seed', 'refresh-dates')]
+    [string] $Mode,
+
+    [string] $DeploymentSettingsPath,
+
+    [switch] $Apply,
+
+    [switch] $NonInteractive,
+
+    [ValidateSet('info', 'debug', 'trace')]
+    [string] $LogLevel
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ─── Resolve repo root ──────────────────────────────────────────────────────
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    Write-Error "install.ps1: not inside a git repo. Run from the HLS-PowerPlatform-Demo working tree."
+    exit 1
+}
+$repoRoot = $repoRoot.Trim()
+
+# ─── Resolve LogLevel from env if not passed ────────────────────────────────
+if (-not $PSBoundParameters.ContainsKey('LogLevel')) {
+    $envLog = $env:LOG_LEVEL
+    if ($envLog) {
+        if ($envLog -in @('info', 'debug', 'trace')) {
+            $LogLevel = $envLog
+        } else {
+            Write-Warning "install.ps1: ignoring invalid LOG_LEVEL='$envLog' from env; using 'info'."
+            $LogLevel = 'info'
+        }
+    } else {
+        $LogLevel = 'info'
+    }
+}
+
+# ─── Resolve DeploymentSettingsPath ─────────────────────────────────────────
+if (-not $DeploymentSettingsPath) {
+    $DeploymentSettingsPath = $env:DEPLOYMENT_SETTINGS_PATH
+    if (-not $DeploymentSettingsPath) {
+        $DeploymentSettingsPath = Join-Path $repoRoot 'scripts/deployment-settings.json'
+    }
+}
+
+# ─── Banner ─────────────────────────────────────────────────────────────────
+$bannerMode = if ($Apply) { '[APPLY]' } else { '[WHATIF — no mutation; pass -Apply to actually run]' }
+Write-Host ""
+Write-Host "─── HLS Power Platform Demo — install.ps1 ─────────────────────────────" -ForegroundColor Cyan
+Write-Host "  Mode:                      $Mode"
+Write-Host "  Deployment settings:       $DeploymentSettingsPath"
+Write-Host "  Apply:                     $bannerMode"
+Write-Host "  Non-interactive:           $($NonInteractive.IsPresent)"
+Write-Host "  Log level:                 $LogLevel"
+Write-Host "  Repo root:                 $repoRoot"
+Write-Host "────────────────────────────────────────────────────────────────────────" -ForegroundColor Cyan
+Write-Host ""
+
+# ─── Mode dispatcher ────────────────────────────────────────────────────────
+
+function Invoke-NotImplemented {
+    param([string] $What, [string] $Topic)
+    Write-Host "[NotImplemented] $What" -ForegroundColor Yellow
+    Write-Host "  See: $Topic" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "This is a Phase 0 skeleton. Real implementation lands in a subsequent sitting." -ForegroundColor DarkGray
+    Write-Host "Exit code 99." -ForegroundColor DarkGray
+    exit 99
+}
+
+switch ($Mode) {
+    'install' {
+        # TODO Lead (Sitting 4g+):
+        #   1. Validate deployment-settings.json against deployment-settings.schema.json
+        #   2. Prompt for missing required env vars (unless -NonInteractive)
+        #   3. Provision Entra app regs (cch_IdEntraAppPagesAuth + cch_IdEntraAppServicePrincipal)
+        #      — see Setup-ServicePrincipal.ps1 (Sitting 4g per Topic 11 §A3)
+        #   4. Provision SharePoint site + Continuum Knowledge library + 4 subfolders
+        #   5. Provision Teams team + 4 channels (Quality, Leadership, Field, Enablement)
+        #      + add SP to team membership; prompt for Graph admin consent for ChannelMessage.Send
+        #   6. Import solution (pac solution import) — empty in Phase 0; tables land Phase 1
+        #   7. Populate Dataverse env vars from settings + EnvVarManifest defaults
+        #   8. Run baseline migration (0001_baseline.ps1) — stamps cch_DeploymentVersion
+        #   9. Insert seed data (via data/seed.ts when Phase 1 ships)
+        #  10. Emit governance scripts (scripts/governance/*.ps1) per Topic 5; print paths.
+        #      Do NOT run them.
+        #  11. Run smoke suite (scripts/lib/Smoke.ps1) — Sitting 5+
+        #  12. Print pre-demo checklist + Demo Health URL
+        Invoke-NotImplemented `
+            -What "install: full first-time provision" `
+            -Topic "Topic 4 (env vars), Topic 5 (governance), Topic 11 §A3 (Entra sequencing)"
+    }
+
+    'upgrade' {
+        # TODO Lead:
+        #   1. Validate deployment-settings.json
+        #   2. Detect schema migrations newer than current cch_DeploymentVersion
+        #   3. Detect new required env vars added since last deploy; prompt for values
+        #      (unless -NonInteractive, in which case fail fast)
+        #   4. Print pre-upgrade summary: solution version delta, migrations to run
+        #      (and how many destructive), agents to republish, env vars needing values,
+        #      connection refs needing binding
+        #   5. If interactive AND there are destructive migrations, confirm; if
+        #      -NonInteractive AND -AllowDestructive not set, fail fast
+        #   6. Run migrations in order
+        #   7. Solution upsert (pac solution import --force-overwrite)
+        #   8. Code App push (pac code push) — when apps/field-companion/ exists
+        #   9. Pages re-publish (pac pages upload + activate) — when sites/continuum-portal/ exists
+        #  10. Agent re-publish (only if version changed; --force-agents overrides)
+        #  11. Insert-only seed updates (--reseed wipes + reseeds)
+        #  12. Run smoke suite
+        #  13. Append entry to cch_DeploymentHistory
+        Invoke-NotImplemented `
+            -What "upgrade: solution upsert + delta migrations + idempotent re-provision" `
+            -Topic "Topic 4 (env-var lifecycle), handoff §3.15 (lifecycle modes + migrations)"
+    }
+
+    'uninstall' {
+        # TODO Lead:
+        #   1. Interactive selection of what to remove (or -YesToAll for scripted)
+        #   2. Default scope: solution + Entra app regs + SharePoint site + Teams team
+        #   3. Confirm before each destructive operation (per scripts/AGENTS.md house rule)
+        #   4. Does NOT default to demo super user delete or DLP/ME removal
+        #   5. With --include-governance: emit Revert-*.ps1 scripts (do not run them)
+        #   6. Append entry to cch_DeploymentHistory before deleting solution
+        Invoke-NotImplemented `
+            -What "uninstall: interactive scope selection + reverse provisioning" `
+            -Topic "Topic 5 (governance not in default uninstall scope), handoff §3.14"
+    }
+
+    'doctor' {
+        # Doctor is read-only and can be invoked directly via scripts/doctor.ps1.
+        # Forward to it preserving relevant flags. Doctor never mutates regardless of -Apply.
+        $doctorPath = Join-Path $repoRoot 'scripts/doctor.ps1'
+        if (-not (Test-Path $doctorPath)) {
+            Write-Error "install.ps1: scripts/doctor.ps1 not found at $doctorPath"
+            exit 1
+        }
+        Write-Host "Delegating to scripts/doctor.ps1 (read-only health check)..." -ForegroundColor DarkCyan
+        Write-Host ""
+        & $doctorPath
+        exit $LASTEXITCODE
+    }
+
+    'seed' {
+        # TODO Dataverse-Engineer (Phase 1):
+        #   1. Load data/names/people.md + data/offsets.ts + data/seed.ts
+        #   2. Generate synthetic rows via Faker (en_US locale)
+        #   3. Insert net-new rows by default; --reseed wipes + reseeds
+        #   4. Tag E2E fixture rows with cch_TestRun = true
+        #   5. Anchor cch_DemoAnchor.LastRefreshedOn = utcnow()
+        Invoke-NotImplemented `
+            -What "seed: Faker-driven synthetic data generation" `
+            -Topic "Topic 7 (Faker en_US), handoff §3.9 (anchor-and-offset), §3.10 (names file)"
+    }
+
+    'refresh-dates' {
+        # TODO Flows-Engineer (Phase 4):
+        #   This mode invokes the daily refresh flow on demand (no cron wait).
+        #   Slides every time-sensitive field forward by elapsed delta from
+        #   cch_DemoAnchor.LastRefreshedOn. Resets MDR-clock complaint to
+        #   cch_TunableMdrClockHours (default 18h).
+        Invoke-NotImplemented `
+            -What "refresh-dates: invoke daily refresh flow on demand" `
+            -Topic "handoff §3.9 (evergreen design), Topic 4 (cch_TunableMdrClockHours)"
+    }
+}

--- a/scripts/lib/EnvVarManifest.json
+++ b/scripts/lib/EnvVarManifest.json
@@ -1,0 +1,576 @@
+{
+    "$schema": "./EnvVarManifest.schema.json",
+    "version": 1,
+    "description": "Machine-readable inventory of all Dataverse Environment Variables the demo solution defines. Authoritative source per Topic 4. Consumed by install.ps1 (prompt for missing required), upgrade.ps1 (detect deltas), doctor.ps1 (validate format + presence), and the Tier-1 schema-drift validator.",
+    "naming": {
+        "prefix": "cch_",
+        "convention": "PascalCase",
+        "format": "cch_<Category><Name>",
+        "exampleValid": "cch_UrlSharePointSite",
+        "exampleInvalid": "CCH_URL_SHAREPOINT_SITE"
+    },
+    "categories": [
+        {
+            "name": "Url",
+            "description": "URLs of provisioned resources. Must be https; must not contain localhost or 127.0.0.1 (locked runtime independence)."
+        },
+        {
+            "name": "Id",
+            "description": "GUIDs / IDs of provisioned resources (Teams team/channel, SharePoint library, Entra app reg, Copilot Studio agent)."
+        },
+        {
+            "name": "Secret",
+            "description": "Secret references via the SecretRef abstraction (Topic 4): plain:<value> or kv:<keyVault>/<secret>[?version=<v>]. Doctor warns on plain:* mode in info-level findings."
+        },
+        {
+            "name": "Tunable",
+            "description": "Demo behavior tunables (cron strings, intervals, MDR clock duration). Per-env overridable."
+        },
+        {
+            "name": "Feature",
+            "description": "Per-vignette / per-feature boolean flags. All ON by default at install (Topic 4)."
+        },
+        {
+            "name": "Brand",
+            "description": "Brand strings surfaced in UI footer / agent salutation / Demo Mode banner."
+        }
+    ],
+    "variables": [
+        {
+            "name": "cch_UrlSharePointSite",
+            "category": "Url",
+            "type": "string",
+            "format": "url",
+            "required": true,
+            "default": null,
+            "source": "operator-input",
+            "description": "SharePoint site holding the Continuum Knowledge library and weekly republished grounding docs.",
+            "readBy": [
+                "Continuum Enablement agent",
+                "Patient Support agent (Patient persona)",
+                "Quality Triage agent",
+                "templated-doc weekly republish flow"
+            ]
+        },
+        {
+            "name": "cch_UrlPagesSite",
+            "category": "Url",
+            "type": "string",
+            "format": "url",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-pac-pages-activate; written-back-by-install",
+            "description": "The deployed Power Pages site URL (V1 + V2 surfaces).",
+            "readBy": [
+                "Patient Support agent V1 deep links",
+                "PostQualityTriageCard 'Open in Quality Workspace' button"
+            ]
+        },
+        {
+            "name": "cch_UrlCodeApp",
+            "category": "Url",
+            "type": "string",
+            "format": "url",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-pac-code-deploy; written-back-by-install",
+            "description": "The deployed Power Apps Code App URL (V3, V4, V5 surfaces).",
+            "readBy": [
+                "TriageCard / ChannelUpdateCard 'Open in app' buttons",
+                "Quality Triage 'Open in Quality Workspace' deep link"
+            ]
+        },
+        {
+            "name": "cch_UrlTeamsTenant",
+            "category": "Url",
+            "type": "string",
+            "format": "url",
+            "required": false,
+            "default": "https://teams.microsoft.com/l/",
+            "source": "default-or-operator-input",
+            "description": "Base URL for composing Teams deep links.",
+            "readBy": [
+                "Adaptive Card deep-link composition"
+            ]
+        },
+        {
+            "name": "cch_UrlGraphBase",
+            "category": "Url",
+            "type": "string",
+            "format": "url",
+            "required": false,
+            "default": "https://graph.microsoft.com/v1.0",
+            "source": "default-or-operator-input",
+            "description": "Microsoft Graph base URL used by Teams channel-post flow.",
+            "readBy": [
+                "Teams channel post flow",
+                "PostQualityTriageCard",
+                "PostTeamsChannelUpdate"
+            ]
+        },
+        {
+            "name": "cch_IdTeamsTeam",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "GUID of the Teams team containing the demo channels (Quality, Field, Enablement, Leadership).",
+            "readBy": [
+                "All Teams channel-post flows"
+            ]
+        },
+        {
+            "name": "cch_IdTeamsChannelQuality",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "Quality Triage Teams channel — receives V4 triage cards.",
+            "readBy": [
+                "PostQualityTriageCard"
+            ]
+        },
+        {
+            "name": "cch_IdTeamsChannelLeadership",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "Leadership Teams channel — receives V4 escalation cards.",
+            "readBy": [
+                "EscalateComplaint"
+            ]
+        },
+        {
+            "name": "cch_IdTeamsChannelField",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "Field team Teams channel — receives V3 FCS channel updates.",
+            "readBy": [
+                "PostTeamsChannelUpdate"
+            ]
+        },
+        {
+            "name": "cch_IdTeamsChannelEnablement",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "Enablement Teams channel — receives V5/V6 enablement-tool result cards (sample orders, training schedules).",
+            "readBy": [
+                "OrderSamples",
+                "ScheduleTraining"
+            ]
+        },
+        {
+            "name": "cch_IdSharePointLibraryKnowledge",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install; written-back",
+            "description": "SharePoint library 'Continuum Knowledge' GUID — agents ground on subfolders inside.",
+            "readBy": [
+                "Continuum Enablement agent grounding",
+                "Patient Support agent FAQ topics",
+                "Quality Triage agent regulatory-glossary lookups",
+                "templated-doc republish flow"
+            ]
+        },
+        {
+            "name": "cch_IdAgentPatientSupport",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "published-by-copilot-studio",
+            "description": "Patient Support agent ID (used for V1 floating bubble + V2 dashboard panel + V3 docked panel).",
+            "readBy": [
+                "AgentChatHost component",
+                "cch_IssueDirectLineToken flow"
+            ]
+        },
+        {
+            "name": "cch_IdAgentQualityTriage",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "published-by-copilot-studio",
+            "description": "Quality Triage agent ID (V4 triggered by cch_TriggerQualityTriage flow + V4 docked analyst chat).",
+            "readBy": [
+                "cch_TriggerQualityTriage",
+                "AgentChatHost component (V4 docked panel)"
+            ]
+        },
+        {
+            "name": "cch_IdAgentEnablement",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "published-by-copilot-studio",
+            "description": "Continuum Enablement agent ID (V5 Knowledge tab + V6 multi-surface).",
+            "readBy": [
+                "AgentChatHost component (V5 fullScreen)",
+                "Teams app manifest",
+                "SharePoint webpart",
+                "M365 Copilot agent picker"
+            ]
+        },
+        {
+            "name": "cch_IdEntraAppPagesAuth",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-install (Lead PR #2 per Topic 11 §A3)",
+            "description": "Entra app registration for Power Pages identity provider.",
+            "readBy": [
+                "Pages auth wiring (sites/continuum-portal/)",
+                "install.ps1 provision-entra-apps mode"
+            ]
+        },
+        {
+            "name": "cch_IdEntraAppServicePrincipal",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": true,
+            "default": null,
+            "source": "provisioned-by-Setup-ServicePrincipal-ps1",
+            "description": "Entra app registration for the service principal used by flows + agent tools (Topic 3 ServicePrincipal Dataverse role).",
+            "readBy": [
+                "Documentation only; not read by flows at runtime"
+            ]
+        },
+        {
+            "name": "cch_IdPipelinesHostEnv",
+            "category": "Id",
+            "type": "string",
+            "format": "guid",
+            "required": false,
+            "default": null,
+            "source": "provisioned-by-Provision-Pipelines-ps1 (Topic 5)",
+            "description": "Power Platform Pipelines host environment ID. Set after Provision-Pipelines.ps1 runs.",
+            "readBy": [
+                "Documentation only"
+            ]
+        },
+        {
+            "name": "cch_SecretDirectLinePatientSupport",
+            "category": "Secret",
+            "type": "string",
+            "format": "secret-ref",
+            "required": true,
+            "default": null,
+            "source": "copilot-studio-channel-config",
+            "description": "Direct Line secret for Patient Support agent. Stored as plain:<value> or kv:<vault>/<secret>.",
+            "readBy": [
+                "cch_IssueDirectLineToken flow"
+            ]
+        },
+        {
+            "name": "cch_SecretDirectLineQualityTriage",
+            "category": "Secret",
+            "type": "string",
+            "format": "secret-ref",
+            "required": true,
+            "default": null,
+            "source": "copilot-studio-channel-config",
+            "description": "Direct Line secret for Quality Triage agent.",
+            "readBy": [
+                "cch_IssueDirectLineToken flow"
+            ]
+        },
+        {
+            "name": "cch_SecretDirectLineEnablement",
+            "category": "Secret",
+            "type": "string",
+            "format": "secret-ref",
+            "required": true,
+            "default": null,
+            "source": "copilot-studio-channel-config",
+            "description": "Direct Line secret for Continuum Enablement agent.",
+            "readBy": [
+                "cch_IssueDirectLineToken flow"
+            ]
+        },
+        {
+            "name": "cch_SecretGraphAppClient",
+            "category": "Secret",
+            "type": "string",
+            "format": "secret-ref",
+            "required": true,
+            "default": null,
+            "source": "Setup-ServicePrincipal-ps1",
+            "description": "App client secret for Microsoft Graph access (Teams channel posts via SP+Graph).",
+            "readBy": [
+                "PostQualityTriageCard",
+                "PostTeamsChannelUpdate",
+                "EscalateComplaint",
+                "OrderSamples",
+                "ScheduleTraining"
+            ]
+        },
+        {
+            "name": "cch_SecretSPClient",
+            "category": "Secret",
+            "type": "string",
+            "format": "secret-ref",
+            "required": true,
+            "default": null,
+            "source": "Setup-ServicePrincipal-ps1",
+            "description": "Service principal client secret (used for Connection Reference setup, not at flow runtime).",
+            "readBy": [
+                "install.ps1 connection reference setup only"
+            ]
+        },
+        {
+            "name": "cch_TunableLiveSimCron",
+            "category": "Tunable",
+            "type": "string",
+            "format": "cron",
+            "required": false,
+            "default": "0 */10 8-18 * * MON-FRI",
+            "source": "default-or-operator-input",
+            "description": "Cron expression for the live-events simulator (default: every 10 min, Mon-Fri, 8 AM-6 PM in cch_TunableTimezone).",
+            "readBy": [
+                "Live-events simulator flow"
+            ]
+        },
+        {
+            "name": "cch_TunableDemoRefreshCron",
+            "category": "Tunable",
+            "type": "string",
+            "format": "cron",
+            "required": false,
+            "default": "0 0 5 * * *",
+            "source": "default-or-operator-input",
+            "description": "Cron expression for the daily demo-data refresh flow (default: 5 AM Eastern).",
+            "readBy": [
+                "Daily refresh flow"
+            ]
+        },
+        {
+            "name": "cch_TunableMdrClockHours",
+            "category": "Tunable",
+            "type": "integer",
+            "format": "positive-int",
+            "required": false,
+            "default": 18,
+            "source": "default-or-operator-input",
+            "description": "Hours remaining on the MDR clock for the V4 hero complaint after each daily refresh (always tense, never expired).",
+            "readBy": [
+                "V4 complaint reset flow"
+            ]
+        },
+        {
+            "name": "cch_TunableShipmentStepSeconds",
+            "category": "Tunable",
+            "type": "integer",
+            "format": "positive-int",
+            "required": false,
+            "default": 30,
+            "source": "default-or-operator-input",
+            "description": "Seconds between Shipment lifecycle stage transitions (compressed-time so audience visibly sees status change during demo).",
+            "readBy": [
+                "Shipment lifecycle advancer flow"
+            ]
+        },
+        {
+            "name": "cch_TunableTimezone",
+            "category": "Tunable",
+            "type": "string",
+            "format": "windows-timezone-id",
+            "required": false,
+            "default": "Eastern Standard Time",
+            "source": "default-or-operator-input",
+            "description": "Windows timezone id used by all scheduled flows + UI date rendering (Topic 7 lock).",
+            "readBy": [
+                "All scheduled flows",
+                "Code App + Pages date rendering"
+            ]
+        },
+        {
+            "name": "cch_FeatureV1PatientPortal",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Pages V1 nav hidden, registration form disabled.",
+            "readBy": [
+                "sites/continuum-portal/ V1 routes"
+            ]
+        },
+        {
+            "name": "cch_FeatureV2HCPPortal",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Pages V2 auth area hidden.",
+            "readBy": [
+                "sites/continuum-portal/ V2 routes"
+            ]
+        },
+        {
+            "name": "cch_FeatureV3FieldCompanion",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Code App 'My Day' / Account 360 hidden.",
+            "readBy": [
+                "apps/field-companion/ V3 routes"
+            ]
+        },
+        {
+            "name": "cch_FeatureV4QualityTriage",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Quality nav hidden in Code App; cch_TriggerQualityTriage disabled.",
+            "readBy": [
+                "apps/field-companion/ V4 routes",
+                "cch_TriggerQualityTriage"
+            ]
+        },
+        {
+            "name": "cch_FeatureV5EnablementKnowledge",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Knowledge tab hidden.",
+            "readBy": [
+                "apps/field-companion/ V5 Knowledge tab"
+            ]
+        },
+        {
+            "name": "cch_FeatureV6ExtendEverywhere",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: Teams app + SP webpart + M365 publish skipped at install.",
+            "readBy": [
+                "install.ps1 V6 surface provisioning",
+                "Teams app manifest"
+            ]
+        },
+        {
+            "name": "cch_FeatureLiveSim",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: live-sim flow paused regardless of cch_LiveSimSetting singleton.",
+            "readBy": [
+                "Live-events simulator flow"
+            ]
+        },
+        {
+            "name": "cch_FeatureDailyRefresh",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "When false: daily refresh flow paused.",
+            "readBy": [
+                "Daily refresh flow"
+            ]
+        },
+        {
+            "name": "cch_FeatureDemoModeBanner",
+            "category": "Feature",
+            "type": "boolean",
+            "required": false,
+            "default": true,
+            "source": "default-or-operator-input",
+            "description": "Escape hatch only. When false: <DemoModeBanner/> returns null. Locked-on for actual demos (Topic 2).",
+            "readBy": [
+                "<DemoModeBanner/> component"
+            ]
+        },
+        {
+            "name": "cch_BrandCompanyName",
+            "category": "Brand",
+            "type": "string",
+            "required": false,
+            "default": "Contoso Continuum Health",
+            "source": "default-or-operator-input",
+            "description": "Company name in UI footer + agent salutations + grounding docs.",
+            "readBy": [
+                "UI shell footer",
+                "Agent system prompts",
+                "Templated-doc rendering"
+            ]
+        },
+        {
+            "name": "cch_BrandPrimaryColor",
+            "category": "Brand",
+            "type": "string",
+            "format": "hex-color",
+            "required": false,
+            "default": "#0E7C86",
+            "source": "default-or-operator-input",
+            "description": "Brand primary teal (locked Topic 2).",
+            "readBy": [
+                "Fluent UI v9 brand ramp in theme.ts",
+                "Adaptive Card severity-color border defaults"
+            ]
+        },
+        {
+            "name": "cch_BrandFooterDisclaimer",
+            "category": "Brand",
+            "type": "string",
+            "required": false,
+            "default": "This is a personal demo asset by Philip Urban (Microsoft Solution Engineer). Not a Microsoft product, sample, or reference architecture. All data is synthetic. AS-IS, no warranty, no support. MIT-licensed.",
+            "source": "default-or-operator-input",
+            "description": "Microsoft-fictitious-disclaimer footer wording (Topic 2 + Topic 9 'What this is NOT').",
+            "readBy": [
+                "UI footer (Pages + Code App)",
+                "Grounding doc footer"
+            ]
+        },
+        {
+            "name": "cch_BrandDemoModeBannerText",
+            "category": "Brand",
+            "type": "string",
+            "required": false,
+            "default": "Demo mode \u2014 synthetic data only",
+            "source": "default-or-operator-input",
+            "description": "Text shown in <DemoModeBanner/> top strip (Topic 2 lock).",
+            "readBy": [
+                "<DemoModeBanner/> component"
+            ]
+        }
+    ]
+}

--- a/scripts/lib/EnvVarManifest.schema.json
+++ b/scripts/lib/EnvVarManifest.schema.json
@@ -1,0 +1,238 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/PhillyUrbs/HLS-PowerPlatform-Demo/scripts/lib/EnvVarManifest.schema.json",
+    "title": "Continuum Env Var Manifest",
+    "description": "Authoritative inventory of cch_* Dataverse Environment Variables per Topic 4 (locked 2026-04-29). Consumed by install.ps1, upgrade.ps1, doctor.ps1, and Tier-1 schema-drift validators.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "version",
+        "naming",
+        "categories",
+        "variables"
+    ],
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "version": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "description": {
+            "type": "string"
+        },
+        "naming": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "prefix",
+                "convention",
+                "format"
+            ],
+            "properties": {
+                "prefix": {
+                    "type": "string",
+                    "const": "cch_"
+                },
+                "convention": {
+                    "type": "string",
+                    "const": "PascalCase"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "exampleValid": {
+                    "type": "string"
+                },
+                "exampleInvalid": {
+                    "type": "string"
+                }
+            }
+        },
+        "categories": {
+            "type": "array",
+            "minItems": 6,
+            "maxItems": 6,
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "description"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": [
+                            "Url",
+                            "Id",
+                            "Secret",
+                            "Tunable",
+                            "Feature",
+                            "Brand"
+                        ]
+                    },
+                    "description": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "variables": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/$defs/EnvVar"
+            }
+        }
+    },
+    "$defs": {
+        "EnvVar": {
+            "type": "object",
+            "required": [
+                "name",
+                "category",
+                "type",
+                "required",
+                "default",
+                "source",
+                "description",
+                "readBy"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "pattern": "^cch_(Url|Id|Secret|Tunable|Feature|Brand)[A-Z][A-Za-z0-9]*$",
+                    "description": "Must match cch_<Category><PascalCaseName>."
+                },
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "Url",
+                        "Id",
+                        "Secret",
+                        "Tunable",
+                        "Feature",
+                        "Brand"
+                    ]
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "integer",
+                        "boolean"
+                    ]
+                },
+                "format": {
+                    "type": "string",
+                    "enum": [
+                        "url",
+                        "guid",
+                        "secret-ref",
+                        "cron",
+                        "positive-int",
+                        "windows-timezone-id",
+                        "hex-color"
+                    ],
+                    "description": "Optional format hint used by doctor's validation rules."
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "default": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Where the value comes from at install: operator-input | provisioned-by-* | published-by-* | default-or-operator-input | copilot-studio-channel-config | Setup-ServicePrincipal-ps1."
+                },
+                "description": {
+                    "type": "string",
+                    "minLength": 10
+                },
+                "readBy": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Free-text list of consumers (flows / agents / components / docs) for traceability."
+                }
+            },
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "category": {
+                                "const": "Url"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "format": {
+                                "const": "url"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "category": {
+                                "const": "Id"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "format": {
+                                "const": "guid"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "category": {
+                                "const": "Secret"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "format": {
+                                "const": "secret-ref"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "category": {
+                                "const": "Feature"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "type": {
+                                "const": "boolean"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/scripts/lib/Secrets.ps1
+++ b/scripts/lib/Secrets.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+    Resolves secret references per the Topic 4 SecretRef abstraction.
+
+.DESCRIPTION
+    Every secret stored in a Dataverse Environment Variable (or a deployment-settings
+    .json file) uses one of two reference formats:
+
+      plain:<value>                                Development mode (default today).
+      kv:<keyVaultName>/<secretName>[?version=<v>] Future Key Vault mode.
+
+    This module exports `Resolve-Secret` which takes a reference string and returns
+    the plain-text secret value. Every PowerShell script and Power Automate child flow
+    (cch_ResolveSecret) routes through this single source of truth so flipping plain →
+    kv later requires zero changes to call sites.
+
+    Per Topic 4: doctor warns on plain: mode in info-level findings; never blocks.
+
+.EXAMPLE
+    Import-Module ./scripts/lib/Secrets.ps1
+    $token = Resolve-Secret -Reference $envvar.cch_SecretDirectLinePatientSupport
+
+.EXAMPLE
+    # KV mode (when operator is ready to migrate)
+    Resolve-Secret -Reference 'kv:cch-demo-kv/DirectLinePatientSupport'
+
+.NOTES
+    Owner role: Lead (per scripts/AGENTS.md).
+    Locked references: Topic 4 §SecretRef abstraction; Topic 11 §C4 doctor warning.
+    Required PowerShell: 7+. KV mode requires Az.KeyVault module installed and
+    operator authenticated (`Connect-AzAccount`); plain mode has no dependencies.
+#>
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-Secret {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        # The secret reference string (plain:<value> or kv:<vault>/<name>[?version=<v>]).
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Reference,
+
+        # Suppress the "consider migrating to Key Vault" warning emitted on plain: refs.
+        [switch] $NoPlainWarning
+    )
+
+    if ($Reference -match '^plain:(?<value>.*)$') {
+        if (-not $NoPlainWarning) {
+            Write-Warning "Resolve-Secret: plain-mode secret reference detected. Consider migrating to Key Vault (kv:<vault>/<name>) for production use."
+        }
+        return $Matches.value
+    }
+
+    if ($Reference -match '^kv:(?<vault>[^/]+)/(?<name>[^?]+)(\?version=(?<version>.+))?$') {
+        $vault   = $Matches.vault
+        $name    = $Matches.name
+        $version = $Matches.version
+
+        if (-not (Get-Module -ListAvailable -Name 'Az.KeyVault')) {
+            throw "Resolve-Secret: kv-mode reference '$Reference' requires the Az.KeyVault module. Install with: Install-Module Az.KeyVault -Scope CurrentUser"
+        }
+
+        Import-Module Az.KeyVault -ErrorAction Stop
+
+        $params = @{
+            VaultName = $vault
+            Name      = $name
+            AsPlainText = $true
+        }
+        if ($version) { $params['Version'] = $version }
+
+        try {
+            $secret = Get-AzKeyVaultSecret @params
+        } catch {
+            throw "Resolve-Secret: failed to read secret '$name' from Key Vault '$vault': $($_.Exception.Message)"
+        }
+        return $secret
+    }
+
+    throw "Resolve-Secret: invalid reference format. Expected 'plain:<value>' or 'kv:<vault>/<name>[?version=<v>]'. Got: '$Reference'"
+}
+
+function Test-SecretReference {
+    <#
+    .SYNOPSIS
+        Validates a secret reference's format without resolving it (used by doctor).
+    .OUTPUTS
+        [pscustomobject] @{ Mode = 'plain' | 'kv' | 'invalid'; Vault = ...; Name = ...; Version = ...; }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Reference
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Reference)) {
+        return [pscustomobject]@{ Mode = 'invalid'; Reason = 'empty or whitespace' }
+    }
+
+    if ($Reference -match '^plain:(?<value>.*)$') {
+        $value = $Matches.value
+        if ($value -match '^<set-me') {
+            return [pscustomobject]@{ Mode = 'invalid'; Reason = 'placeholder template value not replaced' }
+        }
+        return [pscustomobject]@{ Mode = 'plain'; Length = $value.Length }
+    }
+
+    if ($Reference -match '^kv:(?<vault>[^/]+)/(?<name>[^?]+)(\?version=(?<version>.+))?$') {
+        return [pscustomobject]@{
+            Mode    = 'kv'
+            Vault   = $Matches.vault
+            Name    = $Matches.name
+            Version = $Matches.version
+        }
+    }
+
+    return [pscustomobject]@{ Mode = 'invalid'; Reason = 'does not match plain:* or kv:* format' }
+}
+
+# Functions are auto-discoverable by dot-sourcing (`. ./scripts/lib/Secrets.ps1`).
+# When dot-sourced, both Resolve-Secret and Test-SecretReference become available
+# in the caller's scope. No Export-ModuleMember needed (this is a .ps1, not .psm1).

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Thin wrapper for `install.ps1 -Mode uninstall`.
+
+.DESCRIPTION
+    Forwards all arguments to install.ps1 with -Mode uninstall prepended. See
+    install.ps1 for full behavior + parameter docs. Default uninstall scope:
+    solution + Entra app regs + SharePoint site + Teams team. Does NOT default to
+    demo super user delete or DLP/ME removal.
+
+.NOTES
+    Owner role: Lead. Skeleton today; real impl per install.ps1 'uninstall' branch.
+    Confirms before each destructive operation per scripts/AGENTS.md house rule.
+#>
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]] $Args
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) { Write-Error "uninstall.ps1: not inside a git repo."; exit 1 }
+& (Join-Path $repoRoot 'scripts/install.ps1') -Mode uninstall @Args
+exit $LASTEXITCODE

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Thin wrapper for `install.ps1 -Mode upgrade`. Default mode in CI.
+
+.DESCRIPTION
+    Forwards all arguments to install.ps1 with -Mode upgrade prepended. See
+    install.ps1 for full behavior + parameter docs.
+
+.NOTES
+    Owner role: Lead. Skeleton today; real impl per install.ps1 'upgrade' branch.
+#>
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]] $Args
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) { Write-Error "upgrade.ps1: not inside a git repo."; exit 1 }
+& (Join-Path $repoRoot 'scripts/install.ps1') -Mode upgrade @Args
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

Sitting 4 of Phase 0 per Topic 11 §C3 — installer skeletons + the data shape that every other script reads from.

**Real today:**
- `scripts/lib/EnvVarManifest.json` — 40 cch_* env vars from Topic 4 inventory; schema enforces naming (`cch_<Category><Name>`) and per-category constraints.
- `scripts/lib/Secrets.ps1` — `Resolve-Secret` + `Test-SecretReference` per Topic 4 SecretRef abstraction (`plain:<value>` or `kv:<vault>/<name>[?version=<v>]`). 6/6 inline smoke tests pass.
- `scripts/deployment-settings.json.template` + `.schema.json` — categorized operator-edited settings (gitignored after copy). JSON Schema enforces secret-ref oneOf, GUID/URL formats, feature-flag bool|null shape, connection owner enum.

**Skeleton (exit 99 = NotImplemented):**
- `scripts/install.ps1` — mode dispatcher (install/upgrade/uninstall/doctor/seed/refresh-dates), `--whatif` default, `-Apply` required to mutate, structured TODO comments referencing Topic refs.
- `scripts/upgrade.ps1`, `scripts/uninstall.ps1` — thin wrappers.

**Real today (mixed):**
- `scripts/doctor.ps1` — read-only health check, all 8 sections per Topic 11 doctor JSON output schema pin. **5 real passes today** (EnvVarManifest parsed + naming clean + phase.json valid + AGENTS.md present + decisions.md fresh) + 7 honest `[NotImplemented]` info findings. Flags: `--vignette V1..V6` / `--mode full|chained|highlight` / `--section <name>` / `--json`.

## Affected role(s)

- [x] Lead (install/upgrade/uninstall + Secrets.ps1 + EnvVarManifest)
- [x] Tester (doctor.ps1)
- [x] Dataverse-Engineer (EnvVarManifest content reflects Topic 4 inventory)

## Affected phase(s)

- [x] Phase 0 (Tenant & governance setup)

## Decisions

- [x] No new decisions. (Three lessons-learned captured in commit message; not policy decisions.)

## Checks

- [x] Tests added or extended where applicable — 6/6 Secrets.ps1 smoke tests passed locally; doctor.ps1 verified end-to-end with all flag combinations
- [x] Docs updated — comprehensive PowerShell help blocks + inline TODO comments
- [x] No secrets committed
- [x] Branch name matches `feature/p<N>-<name>`
- [x] `--whatif` default for any new state-changing PowerShell script
- [x] Doctor JSON output validates against the Topic 11 pinned schema

## Notes for reviewer

Three small bugs caught + fixed during local smoke testing — captured in commit message for posterity:
1. PowerShell variable case-insensitivity (`$Section` param vs. `$section` foreach)
2. pwsh-on-Windows OEM encoding mangling UTF-8 `§` glyphs in JSON output → switched to ASCII
3. `ConvertTo-Json` without `-Compress` leaves CRLF in string values

Sitting 4g (deferred to a separate PR): `Setup-ServicePrincipal.ps1` + real Entra app reg provisioning per Topic 11 §A3 ordering. That's Lead PR #2 and gates Pages-Engineer's Phase 2 PR #2 (auth wiring).