### PR TITLE
feat(p0): governance scripts (Apply-Dlp/ManagedEnv/Auditing + Provision-Pipelines)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,15 @@ desktop.ini
 *.pfx
 secrets/
 
+# Operator-edited deployment settings (Topic 4 lock — never commit; template is
+# scripts/deployment-settings.json.template which IS committed)
+scripts/deployment-settings.json
+
+# Per-script run logs (governance scripts + future doctor/install logs)
+scripts/.last-run/
+scripts/governance/.last-run/
+scripts/**/.last-run/
+
 # Power Platform — pac CLI artifacts
 .pac/
 *.pacx

--- a/scripts/governance/Apply-Auditing.ps1
+++ b/scripts/governance/Apply-Auditing.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Enables auditing at all 3 layers: tenant + env + every cch_* table.
+
+.DESCRIPTION
+    Per Topic 5 governance lock (2026-04-29): full 3-layer audit trail to back the
+    V4 "every change is traceable" demo beat.
+
+      1. Tenant-level Office 365 audit log (no-op if already enabled in M365 tenant)
+      2. Env-level Dataverse audit
+      3. Per-table cch_* audit (table flags ride with solution import; this script
+         verifies they're applied correctly post-import)
+
+    Column-level auditing on persona-attribution columns + V4 agent-decision columns
+    is declared in the schema by Dataverse-Engineer (Phase 1) and rides with the solution.
+
+    --whatif (default) prints the action plan without mutating anything.
+
+.PARAMETER Apply
+    Switch from --whatif preview to actual mutation.
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-Auditing.ps1
+    Preview only.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-Auditing.ps1 -Apply
+    Actually flip the switches.
+
+.NOTES
+    Owner role: Governance.
+    Topic refs: Topic 5 (audit log scope), Topic 3 (persona-attribution columns),
+                Topic 6 (cch_TelemetryEvent — separate from audit log; this script
+                does NOT touch telemetry).
+    Required PowerShell: 7+. Real impl requires Microsoft.Online.Audit + Microsoft.Xrm.Data.PowerShell.
+    Exit codes: 0 success | 1 user-facing error | 99 not yet implemented (skeleton).
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [switch] $Apply,
+    [string] $DeploymentSettingsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '../lib/Governance.ps1')
+
+$settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+
+Write-GovernanceBanner `
+    -ScriptName 'Apply-Auditing.ps1' `
+    -Purpose 'Enable auditing at tenant + env + every cch_* table (3 layers)' `
+    -Apply $Apply.IsPresent `
+    -Settings $settings
+
+$plannedActions = @(
+    "Layer 1 -- Tenant (Office 365 audit log):"
+    "  - Connect to Exchange Online admin"
+    "  - Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled \$true (idempotent; usually on)"
+    ""
+    "Layer 2 -- Environment (Dataverse audit):"
+    "  - Connect to target env '$($settings.environment.url)'"
+    "  - Set OrgDbOrgSettings:"
+    "      AuditLog = on"
+    "      RetentionDays = 90 (default)"
+    ""
+    "Layer 3 -- Per-table cch_* audit:"
+    "  - List all tables matching prefix 'cch_' from solution metadata"
+    "  - Verify each has IsAuditEnabled = true"
+    "  - Report count of tables already audit-enabled at solution-import time"
+    "  - Warn (not fail) if any cch_* table lacks audit (Dataverse-Engineer Phase-1 fix)"
+    ""
+    "Column-level audit (NOT mutated by this script -- declared in schema):"
+    "  - cch_CreatedByPersona, cch_ModifiedByPersona on every audit-relevant table"
+    "  - V4 agent-decision columns on cch_Complaint:"
+    "      cch_AgentClassification, cch_AgentSeverity, cch_AgentConfidence,"
+    "      cch_AgentRationale, cch_AnalystOverride, cch_MdrDraft"
+    ""
+    "After apply: doctor's [Governance] section reports counts; the V4 demo beat"
+    "can claim 'every change to this complaint is in the audit log -- including which"
+    "agent / persona made each edit'."
+)
+
+Invoke-GovernanceNotImplemented `
+    -ScriptName 'Apply-Auditing.ps1' `
+    -Purpose 'Audit at tenant + env + per-table layers' `
+    -TopicRef 'Topic 5 (audit scope) + Topic 3 (persona-attribution columns)' `
+    -PlannedActions $plannedActions `
+    -Apply $Apply.IsPresent

--- a/scripts/governance/Apply-Dlp.ps1
+++ b/scripts/governance/Apply-Dlp.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Applies a custom Data Loss Prevention policy to the demo dev env.
+
+.DESCRIPTION
+    Per Topic 5 governance lock (2026-04-29):
+      - Scope: the named demo dev env from deployment-settings.json (not tenant-wide).
+      - Business bucket: locked baseline (Dataverse, Outlook, Teams, SharePoint,
+        Approvals, HTTP-with-Entra) + Direct Line + OneDrive for Business + Power BI
+        + Word/Excel Online + Microsoft Forms.
+      - Non-Business bucket: empty.
+      - Everything else: Blocked.
+
+    --whatif (default) prints the action plan without mutating anything.
+    -Apply runs the actual Set-AdminDlpPolicy / similar admin cmdlets (Phase 1+).
+
+    Idempotent: re-running with the same manifest is a no-op. Logs to
+    scripts/governance/.last-run/Apply-Dlp.log.
+
+.PARAMETER Apply
+    Switch from --whatif preview to actual mutation. Default is --whatif.
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-Dlp.ps1
+    Preview only (--whatif default). Prints the planned bucket assignments + target env.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-Dlp.ps1 -Apply
+    Actually creates / updates the DLP policy on the target env.
+
+.NOTES
+    Owner role: Governance.
+    Topic refs: Topic 5 (DLP scope + Business bucket members), Topic 5 (intentionally OFF
+                features documented in commented-out blocks below for operator reference).
+    Required PowerShell: 7+. Real impl requires Microsoft.PowerApps.Administration.PowerShell.
+    Exit codes: 0 success | 1 user-facing error | 99 not yet implemented (skeleton).
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [switch] $Apply,
+    [string] $DeploymentSettingsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '../lib/Governance.ps1')
+
+$settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+
+Write-GovernanceBanner `
+    -ScriptName 'Apply-Dlp.ps1' `
+    -Purpose 'Custom DLP policy: Business / Blocked split, scoped to demo dev env' `
+    -Apply $Apply.IsPresent `
+    -Settings $settings
+
+$plannedActions = @(
+    "Connect to Power Platform admin (Connect-PowerAppsAccount or service principal)"
+    "Verify target env '$($settings.environment.name)' exists and is accessible"
+    "Create or update DLP policy 'cch-demo-dlp' scoped to env id (looked up by url)"
+    ""
+    "BUSINESS bucket (combinable):"
+    "  - Microsoft Dataverse"
+    "  - Office 365 Outlook"
+    "  - Microsoft Teams"
+    "  - SharePoint Online"
+    "  - Approvals"
+    "  - HTTP with Microsoft Entra ID (preauthorized)"
+    "  - Direct Line                  (Topic 5 addition: required for V3/V4/V5 chats)"
+    "  - OneDrive for Business        (Topic 5 addition: hybrid connection ownership)"
+    "  - Power BI                     (Topic 5 addition: defensive for placeholder tiles)"
+    "  - Word / Excel Online (Business) (Topic 5 addition: templated-doc republish flow)"
+    "  - Microsoft Forms              (Topic 5 addition: forms-driven Approvals)"
+    ""
+    "NON-BUSINESS bucket: <empty> (locked Topic 5; sharpens demo posture)"
+    ""
+    "BLOCKED: everything else (default)"
+    ""
+    "INTENTIONALLY NOT in Business (commented blocks operator can flip):"
+    "  - Azure family (Functions/Storage/Service Bus) -- violates runtime independence"
+    "  - LinkedIn / X / Mailchimp -- not used by demo"
+    ""
+    "After apply: write audit-permissions Tier-1 will validate the bucket assignments"
+    "match this manifest on every Pages-touching PR."
+)
+
+Invoke-GovernanceNotImplemented `
+    -ScriptName 'Apply-Dlp.ps1' `
+    -Purpose 'Custom DLP policy' `
+    -TopicRef 'Topic 5 (governance config) + handoff section 3.13 (governance approach)' `
+    -PlannedActions $plannedActions `
+    -Apply $Apply.IsPresent

--- a/scripts/governance/Apply-ManagedEnv.ps1
+++ b/scripts/governance/Apply-ManagedEnv.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Converts the demo dev env to Managed Environment + enables a curated feature set.
+
+.DESCRIPTION
+    Per Topic 5 governance lock (2026-04-29):
+
+    ENABLED features:
+      - Solution Checker enforcement + weekly run
+      - Maker welcome content + usage insights dashboard
+      - Custom solution-checker rules (PA-prefer-environment-variable,
+        PA-prefer-connection-reference)
+      - Catalog publishing (so the demo solution shows up in the env catalog;
+        supports the V6 governance-closer admin-screen-share)
+
+    INTENTIONALLY OFF (commented blocks below; operator can flip individually):
+      - Limit sharing of canvas apps + app/flow inactive cleanup
+      - IP firewall restrictions
+      - Customer Lockbox
+
+    --whatif (default) prints the action plan without mutating anything.
+
+.PARAMETER Apply
+    Switch from --whatif preview to actual mutation.
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-ManagedEnv.ps1
+    Preview only.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Apply-ManagedEnv.ps1 -Apply
+    Actually convert env to ME + enable the locked feature set.
+
+.NOTES
+    Owner role: Governance.
+    Topic refs: Topic 5 (ME features enabled / not enabled).
+    Required PowerShell: 7+. Real impl requires Microsoft.PowerApps.Administration.PowerShell.
+    Exit codes: 0 success | 1 user-facing error | 99 not yet implemented (skeleton).
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [switch] $Apply,
+    [string] $DeploymentSettingsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '../lib/Governance.ps1')
+
+$settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+
+Write-GovernanceBanner `
+    -ScriptName 'Apply-ManagedEnv.ps1' `
+    -Purpose 'Convert dev env to Managed Environment + enable curated features' `
+    -Apply $Apply.IsPresent `
+    -Settings $settings
+
+$plannedActions = @(
+    "Connect to Power Platform admin"
+    "Verify target env '$($settings.environment.name)' is not already Managed (idempotent: skip if already)"
+    "Convert env to Managed Environment"
+    ""
+    "ENABLE (locked Topic 5):"
+    "  - Solution Checker enforcement (block import on rule violations) + weekly run"
+    "  - Maker welcome content (banner + tour for new makers)"
+    "  - Usage insights dashboard"
+    "  - Custom solution-checker rules:"
+    "      * PA-prefer-environment-variable"
+    "      * PA-prefer-connection-reference"
+    "  - Catalog publishing (demo solution discoverable in env catalog)"
+    ""
+    "INTENTIONALLY OFF (Topic 5 documented; commented in script for operator override):"
+    "  - Limit sharing of canvas apps + app/flow inactive cleanup"
+    "      Reason: personal demo asset doesn't accumulate orphans at a rate that"
+    "      justifies demo-time risk of a flow being auto-disabled mid-vignette."
+    "  - IP firewall restrictions"
+    "      Reason: blocks operators behind home networks; for prod tenants only."
+    "  - Customer Lockbox"
+    "      Reason: Microsoft-support-access feature; meaningless for personal demo."
+)
+
+Invoke-GovernanceNotImplemented `
+    -ScriptName 'Apply-ManagedEnv.ps1' `
+    -Purpose 'Managed Environment conversion + feature enablement' `
+    -TopicRef 'Topic 5 (governance config) + handoff section 3.13' `
+    -PlannedActions $plannedActions `
+    -Apply $Apply.IsPresent

--- a/scripts/governance/Provision-Pipelines.ps1
+++ b/scripts/governance/Provision-Pipelines.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Provisions the Power Platform Pipelines host env + 2 stage placeholders pointing back at dev (no-op).
+
+.DESCRIPTION
+    Per Topic 5 governance lock (2026-04-29) + handoff section 3.13:
+
+    "provision Pipelines host now (no targets) so adding Test/Prod later is non-breaking"
+
+    Specifically:
+      - Create a small host environment (separate from the dev env)
+      - Register the dev env as a deployable env
+      - Define two stage *placeholders* (`Test`, `Prod`) whose target is **the dev env itself**
+        — accidental "deploy to Prod" becomes a no-op.
+      - Operator later edits the placeholders to point at real Test/Prod envs when those exist.
+
+    Sets cch_IdPipelinesHostEnv (env var) on success.
+
+    --whatif (default) prints the action plan without mutating anything.
+
+.PARAMETER Apply
+    Switch from --whatif preview to actual mutation.
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Provision-Pipelines.ps1
+    Preview only.
+
+.EXAMPLE
+    pwsh ./scripts/governance/Provision-Pipelines.ps1 -Apply
+    Actually create the host env + register stage placeholders.
+
+.NOTES
+    Owner role: Governance.
+    Topic refs: Topic 5 (Pipelines section) + handoff section 3.13.
+    Required PowerShell: 7+. Real impl requires Microsoft.PowerApps.Administration.PowerShell
+    + Pipelines REST API.
+    Exit codes: 0 success | 1 user-facing error | 99 not yet implemented (skeleton).
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [switch] $Apply,
+    [string] $DeploymentSettingsPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot '../lib/Governance.ps1')
+
+$settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+
+Write-GovernanceBanner `
+    -ScriptName 'Provision-Pipelines.ps1' `
+    -Purpose 'Pipelines host env + 2 stage placeholders pointing back at dev (no-op)' `
+    -Apply $Apply.IsPresent `
+    -Settings $settings
+
+$plannedActions = @(
+    "Connect to Power Platform admin"
+    "Check for existing Pipelines host env (cch_IdPipelinesHostEnv in settings)"
+    "  - If set: verify it exists; idempotent skip if so"
+    "  - If unset: create new env named '<env-name>-pipelines-host' (small / sandbox tier)"
+    ""
+    "Provision Pipelines on the host env"
+    "  - Install the Power Platform Pipelines maker app + admin app"
+    "  - Create the cch_DeployableEnvironments record for the dev env"
+    "      (target env id = '$($settings.environment.url)' looked up to env id)"
+    ""
+    "Define 2 stage placeholders (no-op):"
+    "  - Stage 'Test'  -> target env = dev env id  (accidental deploy = no-op)"
+    "  - Stage 'Prod'  -> target env = dev env id  (accidental deploy = no-op)"
+    ""
+    "Write back cch_IdPipelinesHostEnv to deployment-settings.json"
+    ""
+    "When operator is ready to add real Test/Prod envs:"
+    "  1. Provision separate Test + Prod envs (operator's tenant decision)"
+    "  2. Edit the stage placeholders in the Pipelines maker app to point at"
+    "     the real env ids (replacing dev id)"
+    "  3. No code change required; the install.ps1 lifecycle modes work the same"
+    ""
+    "Doctor's [Governance] section will report:"
+    "  - Pipelines host env present?  (info if not provisioned -- optional)"
+    "  - Dev env registered?           (pass/info)"
+)
+
+Invoke-GovernanceNotImplemented `
+    -ScriptName 'Provision-Pipelines.ps1' `
+    -Purpose 'Pipelines host + no-op stage placeholders' `
+    -TopicRef 'Topic 5 (Pipelines section) + handoff section 3.13' `
+    -PlannedActions $plannedActions `
+    -Apply $Apply.IsPresent

--- a/scripts/lib/Governance.ps1
+++ b/scripts/lib/Governance.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    Shared helpers for governance scripts. Dot-source from Apply-*.ps1 / Provision-*.ps1.
+
+.DESCRIPTION
+    Per Topic 5 governance lock + Topic 11 section C3 multi-sitting Phase 0:
+    every governance script defaults to --whatif (preview-only), is idempotent,
+    reads target env from deployment-settings.json, and logs to scripts/governance/.last-run/<name>.log.
+
+    This file factors out the boilerplate. Consumers dot-source it:
+      . (Join-Path $PSScriptRoot '../lib/Governance.ps1')
+
+.NOTES
+    Owner role: Governance (per scripts/AGENTS.md).
+    Topic refs: Topic 5 (governance config), Topic 11 section C3 (multi-sitting), Topic 11 doctor JSON pin.
+    Required PowerShell: 7+.
+    Exit codes (consumers should use these):
+      0   success (whatif preview emitted, OR apply succeeded)
+      1   user-facing error (settings missing, env unreachable, etc.)
+      99  not yet implemented (skeleton)
+#>
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    $root = git rev-parse --show-toplevel 2>$null
+    if (-not $root) {
+        throw "Governance.ps1: not inside a git repo. Run from the HLS-PowerPlatform-Demo working tree."
+    }
+    return $root.Trim()
+}
+
+function Read-DeploymentSettings {
+    <#
+    .SYNOPSIS
+        Loads scripts/deployment-settings.json (or path override) and validates required top-level keys exist.
+        Returns the parsed object, or throws if the file is missing / malformed.
+    #>
+    [CmdletBinding()]
+    [OutputType([psobject])]
+    param(
+        [string] $Path
+    )
+
+    if (-not $Path) {
+        $Path = $env:DEPLOYMENT_SETTINGS_PATH
+    }
+    if (-not $Path) {
+        $Path = Join-Path (Get-RepoRoot) 'scripts/deployment-settings.json'
+    }
+
+    if (-not (Test-Path $Path)) {
+        throw "Read-DeploymentSettings: file not found at '$Path'. Copy scripts/deployment-settings.json.template and fill in values."
+    }
+
+    try {
+        $settings = Get-Content $Path -Raw | ConvertFrom-Json
+    } catch {
+        throw "Read-DeploymentSettings: failed to parse '$Path' as JSON: $($_.Exception.Message)"
+    }
+
+    # Minimum-viable shape check (full schema validation deferred to Tier-1 ajv-cli).
+    foreach ($key in @('environment', 'superUsers', 'tenant')) {
+        if (-not $settings.PSObject.Properties.Name.Contains($key)) {
+            throw "Read-DeploymentSettings: '$Path' missing required top-level key '$key'."
+        }
+    }
+    if (-not $settings.environment.PSObject.Properties.Name.Contains('url')) {
+        throw "Read-DeploymentSettings: 'environment.url' is required in '$Path'."
+    }
+
+    return $settings
+}
+
+function Write-GovernanceBanner {
+    <#
+    .SYNOPSIS
+        Prints the standard banner shared by every governance script.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $ScriptName,
+        [Parameter(Mandatory)] [string] $Purpose,
+        [Parameter(Mandatory)] [bool]   $Apply,
+        [Parameter(Mandatory)] [psobject] $Settings
+    )
+    $modeBanner = if ($Apply) {
+        '[APPLY -- WILL MUTATE]'
+    } else {
+        '[WHATIF -- preview only; pass -Apply to actually run]'
+    }
+
+    Write-Host ""
+    Write-Host "--- Governance: $ScriptName -----------------------------------------" -ForegroundColor Cyan
+    Write-Host "  Purpose:           $Purpose"
+    Write-Host "  Target env:        $($Settings.environment.name) ($($Settings.environment.url))"
+    Write-Host "  Mode:              $modeBanner"
+    Write-Host "----------------------------------------------------------------------" -ForegroundColor Cyan
+    Write-Host ""
+}
+
+function New-GovernanceLogPath {
+    <#
+    .SYNOPSIS
+        Returns the path to scripts/governance/.last-run/<name>.log, ensuring the dir exists.
+        Logs are gitignored (.gitignore: scripts/governance/.last-run/).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)] [string] $ScriptName
+    )
+    $dir = Join-Path (Get-RepoRoot) 'scripts/governance/.last-run'
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    Join-Path $dir "$ScriptName.log"
+}
+
+function Invoke-GovernanceNotImplemented {
+    <#
+    .SYNOPSIS
+        Standard skeleton exit per Topic 11 section C3 -- Phase-0 governance scripts emit
+        the planned action plan (preview), then exit 99.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]   $ScriptName,
+        [Parameter(Mandatory)] [string]   $Purpose,
+        [Parameter(Mandatory)] [string]   $TopicRef,
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
+        [string[]] $PlannedActions,
+        [bool] $Apply = $false
+    )
+    Write-Host "Planned actions (when implemented):" -ForegroundColor DarkCyan
+    foreach ($action in $PlannedActions) {
+        if ([string]::IsNullOrWhiteSpace($action)) {
+            Write-Host ""
+        } else {
+            Write-Host "  $action" -ForegroundColor DarkGray
+        }
+    }
+    Write-Host ""
+    if ($Apply) {
+        Write-Host "[NotImplemented] -Apply requested but '$ScriptName' has no real implementation yet." -ForegroundColor Yellow
+    } else {
+        Write-Host "[NotImplemented] '$ScriptName' is a Phase-0 skeleton." -ForegroundColor Yellow
+    }
+    Write-Host "  See: $TopicRef" -ForegroundColor DarkGray
+    Write-Host "  Real implementation lands in a subsequent sitting." -ForegroundColor DarkGray
+    Write-Host "  Exit code 99." -ForegroundColor DarkGray
+    exit 99
+}


### PR DESCRIPTION
## Summary

Sitting 5 of Phase 0. Four governance script skeletons + a shared lib + a security-relevant gitignore fix.

**Per Topic 5 governance lock:**
- All 4 scripts default to `--whatif` (preview only); `-Apply` switches to mutation
- Idempotent; safe to re-run
- Read target env from `deployment-settings.json` via shared `scripts/lib/Governance.ps1`
- `install.ps1` emits paths but never runs them (locked rule + handoff §3.14)
- Doctor reports posture; never changes data

**4 scripts (each ~95 lines, exit 99 = NotImplemented; planned actions enumerated):**
- `Apply-Dlp.ps1` — Business bucket = locked baseline + 5 Topic-5 additions; Non-Business empty; everything else Blocked. Scoped to dev env only.
- `Apply-ManagedEnv.ps1` — Solution Checker enforcement + Maker welcome/usage + custom rules + Catalog publishing. Documents intentionally-OFF features (sharing-limit, IP firewall, Customer Lockbox) for operator reference.
- `Apply-Auditing.ps1` — 3 layers: tenant + env + per-table cch_*. Column-level audit declared in schema by Dataverse-Engineer (Phase 1).
- `Provision-Pipelines.ps1` — host env + 2 stage placeholders pointing back at dev (no-op until edited).

**Security-relevant gitignore fix (Sitting 1 oversight caught here):**
- `scripts/deployment-settings.json` now ignored (per Topic 4 lock — operator's real values; never commit).
- `scripts/.last-run/` + `scripts/governance/.last-run/` ignored (per-script run logs).

## Affected role(s)

- [x] Governance (4 scripts + content)
- [x] Lead (shared lib + gitignore fix)

## Affected phase(s)

- [x] Phase 0 (Tenant & governance setup)

## Decisions

- [x] No new decisions. Two lessons learned captured in commit message:
  - PowerShell ValidateNotNullOrEmpty rejects empty strings used as section dividers
  - Same § (U+00A7) glyph mangling on pwsh-Windows; consistently using 'section X' in source

## Checks

- [x] Tests added or extended where applicable — all 4 scripts smoke-tested locally; exit 99, structured output verified
- [x] Docs updated — comprehensive PowerShell help + planned-actions enumeration in each script
- [x] No secrets committed — and now, no secrets *can* be committed (deployment-settings.json gitignored)
- [x] `--whatif` default for any new state-changing PowerShell script
- [x] Branch name matches `feature/p<N>-<name>`

## Notes for reviewer

The gitignore catch is worth a beat — `scripts/deployment-settings.json` was always documented as gitignored (Topic 4) but the actual gitignore pattern was missed in Sitting 1. Caught + fixed during Sitting 5 smoke testing when I had to create a test deployment-settings.json to exercise the governance scripts. `git check-ignore` confirms it's now ignored.

Sitting 6 next: open the 9 first-PR-target GitHub issues with phase + role labels.