### PR TITLE
feat(p0): Setup-ServicePrincipal.ps1 + EntraApps lib + install.ps1 step 1-3

### DIFF
--- a/scripts/Setup-ServicePrincipal.ps1
+++ b/scripts/Setup-ServicePrincipal.ps1
@@ -1,0 +1,297 @@
+<#
+.SYNOPSIS
+    Provisions the Entra app registration that flows + agent tools authenticate as.
+    Adds it as a Dataverse Application User on the target env.
+
+.DESCRIPTION
+    Per Topic 3 connection-ownership lock + Topic 11 section A3 sequencing:
+    this script delivers the cch_IdEntraAppServicePrincipal env var. Run once per tenant.
+
+    Uses `pac admin create-service-principal` which performs THREE operations atomically:
+      1. Creates an Entra app registration in the operator's tenant
+      2. Generates a client secret
+      3. Adds the resulting SP as a Dataverse Application User on the target env
+         with the assigned security role.
+
+    Per Topic 11 section C8 + Topic 4: secret is written back to deployment-settings.json
+    using the SecretRef abstraction (`plain:<value>`). Operator can later migrate
+    to Key Vault by editing the value to `kv:<vault>/<name>` with no flow rewrites.
+
+    --whatif (default) prints the action plan + checks for existing SP without mutating.
+    -Apply runs `pac admin create-service-principal` for real.
+
+    Idempotent: if cch_IdEntraAppServicePrincipal already set in deployment-settings.json
+    AND --Force not passed, exits early with "already provisioned" message.
+
+.PARAMETER Apply
+    Switch from --whatif preview to actual mutation. Default is --whatif.
+
+.PARAMETER DeploymentSettingsPath
+    Path to deployment-settings.json. Defaults to scripts/deployment-settings.json.
+
+.PARAMETER ApplicationName
+    Display name for the Entra app reg. Defaults to "<env-name>-sp" derived from
+    deployment-settings.json environment.name (lowercased + sanitized).
+
+.PARAMETER SecurityRole
+    Dataverse security role to assign the new app user.
+    Default: 'System Administrator' (per `pac admin create-service-principal` default).
+
+    PHASE 1 NOTE: After Dataverse-Engineer's PR #1 (issue #5) lands the bespoke
+    'ServicePrincipal' role per Topic 3, change this default to 'ServicePrincipal'.
+
+.PARAMETER Force
+    Re-provision even if cch_IdEntraAppServicePrincipal is already set in
+    deployment-settings.json. Creates a NEW Entra app + leaves the old one alone
+    (does not delete). Operator must manually clean up.
+
+.EXAMPLE
+    pwsh ./scripts/Setup-ServicePrincipal.ps1
+    Preview only (--whatif default). Reads target env, checks for existing SP,
+    prints what would happen.
+
+.EXAMPLE
+    pwsh ./scripts/Setup-ServicePrincipal.ps1 -Apply
+    Actually creates the Entra app + Dataverse Application User. Writes back to
+    deployment-settings.json.
+
+.EXAMPLE
+    pwsh ./scripts/Setup-ServicePrincipal.ps1 -Apply -ApplicationName 'continuum-demo-sp'
+    Use a custom app reg display name.
+
+.NOTES
+    Owner role: Lead (per scripts/AGENTS.md).
+    Topic refs: Topic 3 (connection ownership + ServicePrincipal role),
+                Topic 4 (cch_IdEntraAppServicePrincipal + cch_SecretSPClient + SecretRef),
+                Topic 11 section A3 (Lead PR #2 sequencing).
+    Required PowerShell: 7+. Required CLI: pac 2.6+.
+    Required auth: operator must have run `pac auth create -url <env-url>` first AND
+                   have either Global admin / Power Platform admin / Application admin
+                   role in the tenant (to create app regs).
+
+    Out of scope (separate concerns):
+      - cch_IdEntraAppPagesAuth -- handled by install.ps1 -Mode install via scripts/lib/EntraApps.ps1
+        (separate Entra app reg with web-app redirect URI; uses az ad app create)
+      - Microsoft Graph admin consent for ChannelMessage.Send -- separately printed by
+        install.ps1 with operator-confirms-once-per-tenant pattern
+
+    Exit codes:
+      0   success (whatif preview emitted, OR apply succeeded, OR already provisioned)
+      1   user-facing error (settings missing, env unreachable, pac auth failure)
+      2   pac command failed unexpectedly
+      99  not yet implemented (this script is REAL, not a skeleton; this exit code is
+          here for shape consistency only)
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [switch] $Apply,
+    [string] $DeploymentSettingsPath,
+    [string] $ApplicationName,
+    [string] $SecurityRole = 'System Administrator',
+    [switch] $Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/Governance.ps1')
+. (Join-Path $PSScriptRoot 'lib/Secrets.ps1')
+
+# ─── Pre-flight ─────────────────────────────────────────────────────────────
+
+if (-not (Get-Command pac -ErrorAction SilentlyContinue)) {
+    Write-Error "Setup-ServicePrincipal: 'pac' CLI not found on PATH. Install from https://aka.ms/pacinstall."
+    exit 1
+}
+
+$settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+
+# Derive default app name from env name (sanitized) if not passed
+if (-not $ApplicationName) {
+    $envName = $settings.environment.name
+    $sanitized = ($envName -replace '[^A-Za-z0-9]+', '-').ToLowerInvariant().Trim('-')
+    $ApplicationName = "$sanitized-sp"
+}
+
+# ─── Banner ─────────────────────────────────────────────────────────────────
+
+Write-GovernanceBanner `
+    -ScriptName 'Setup-ServicePrincipal.ps1' `
+    -Purpose 'Provision Entra app reg + Dataverse Application User for service principal' `
+    -Apply $Apply.IsPresent `
+    -Settings $settings
+
+Write-Host "  Application name:  $ApplicationName"
+Write-Host "  Security role:     $SecurityRole"
+Write-Host "  Force re-provision:$($Force.IsPresent)"
+Write-Host ""
+
+# ─── Idempotency check ──────────────────────────────────────────────────────
+
+$existingId = $null
+if ((Test-PSObjectProperty -InputObject $settings -PropertyName 'ids') -and
+    (Test-PSObjectProperty -InputObject $settings.ids -PropertyName 'cch_IdEntraAppServicePrincipal')) {
+    $existingId = $settings.ids.cch_IdEntraAppServicePrincipal
+}
+
+if ($existingId -and -not $Force) {
+    Write-Host "[idempotent skip] cch_IdEntraAppServicePrincipal already set: $existingId" -ForegroundColor Green
+    Write-Host "  Pass -Force to re-provision (creates a NEW app reg; old one is NOT deleted)." -ForegroundColor DarkGray
+    exit 0
+}
+
+# ─── Action plan ────────────────────────────────────────────────────────────
+
+$plannedActions = @(
+    "Verify pac auth context targets '$($settings.environment.url)'"
+    "Run: pac admin create-service-principal --environment '$($settings.environment.url)' --name '$ApplicationName' --role '$SecurityRole'"
+    "Capture from output:"
+    "  - Application (client) ID  -> cch_IdEntraAppServicePrincipal"
+    "  - Tenant ID                -> validate matches deployment-settings.tenant.id"
+    "  - Generated client secret  -> cch_SecretSPClient (wrapped as plain:<value>)"
+    ""
+    "Write back to deployment-settings.json:"
+    "  ids.cch_IdEntraAppServicePrincipal = <application-id>"
+    "  secrets.cch_SecretSPClient         = plain:<generated-secret>"
+    ""
+    "Verify the SP appears in 'pac admin list-service-principal' for the env"
+    ""
+    "PHASE 1 follow-up: after Dataverse-Engineer issue #5 lands the bespoke"
+    "'ServicePrincipal' security role, re-run with -SecurityRole 'ServicePrincipal'"
+    "to downgrade from System Administrator to least-privilege."
+)
+
+if (-not $Apply) {
+    # --whatif mode: print plan and exit 0 (preview success; the script IS implemented)
+    Show-GovernancePreview `
+        -ScriptName 'Setup-ServicePrincipal.ps1' `
+        -PlannedActions $plannedActions
+}
+
+# ─── -Apply path ────────────────────────────────────────────────────────────
+
+Write-Host "[Apply] Running pac admin create-service-principal..." -ForegroundColor Yellow
+Write-Host "  This will:" -ForegroundColor DarkGray
+Write-Host "    * Create an Entra app registration named '$ApplicationName' in your tenant" -ForegroundColor DarkGray
+Write-Host "    * Generate a client secret (you must capture it)" -ForegroundColor DarkGray
+Write-Host "    * Add the SP as a Dataverse Application User on $($settings.environment.url)" -ForegroundColor DarkGray
+Write-Host "    * Assign security role '$SecurityRole'" -ForegroundColor DarkGray
+Write-Host ""
+
+$logPath = New-GovernanceLogPath -ScriptName 'Setup-ServicePrincipal'
+Write-Host "  Logging to: $logPath" -ForegroundColor DarkGray
+Write-Host ""
+
+# Capture pac output. pac writes structured-ish text; we parse for the IDs.
+try {
+    $pacOutput = & pac admin create-service-principal `
+        --environment $settings.environment.url `
+        --name $ApplicationName `
+        --role $SecurityRole 2>&1
+    $pacExitCode = $LASTEXITCODE
+} catch {
+    Write-Error "Setup-ServicePrincipal: pac admin create-service-principal threw: $($_.Exception.Message)"
+    exit 2
+}
+
+# Persist full pac output to log
+$pacOutput | Out-File -FilePath $logPath -Encoding utf8
+
+if ($pacExitCode -ne 0) {
+    Write-Error "Setup-ServicePrincipal: pac admin create-service-principal failed (exit $pacExitCode). See log: $logPath"
+    exit 2
+}
+
+# Parse pac output. Format (verified 2026-04-29 against pac 2.6.4):
+#   Application Name         <name>
+#   Tenant Id                xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+#   Application Id           xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+#   Service Principal Id     xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+#   Client Secret            <secret>
+#   Client Secret Expiration <date>
+#   System User Id           xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# Note: 'Id' (not 'ID'), no colon separator, whitespace-aligned columns.
+$outputText = $pacOutput -join "`n"
+
+$tenantIdMatch = [regex]::Match($outputText, '^\s*Tenant\s+Id\s+(?<id>[0-9a-fA-F-]{36})\s*$', 'Multiline')
+$appIdMatch    = [regex]::Match($outputText, '^\s*Application\s+Id\s+(?<id>[0-9a-fA-F-]{36})\s*$', 'Multiline')
+# Client secret has no fixed format -- match everything after "Client Secret" up to end-of-line.
+# Avoid matching the "Client Secret Expiration" line by requiring the next non-whitespace
+# after "Secret" to NOT be 'Expiration'.
+$secretMatch   = [regex]::Match($outputText, '^\s*Client\s+Secret\s+(?!Expiration)(?<secret>\S+)\s*$', 'Multiline')
+
+if (-not $appIdMatch.Success) {
+    Write-Error "Setup-ServicePrincipal: could not parse Application ID from pac output. See log: $logPath"
+    exit 2
+}
+if (-not $secretMatch.Success) {
+    Write-Error "Setup-ServicePrincipal: could not parse Client Secret from pac output. See log: $logPath"
+    exit 2
+}
+
+$newAppId  = $appIdMatch.Groups['id'].Value
+$newSecret = $secretMatch.Groups['secret'].Value
+
+Write-Host "[Apply] pac succeeded:" -ForegroundColor Green
+Write-Host "  Application (client) ID: $newAppId" -ForegroundColor Green
+Write-Host "  Client secret captured (length $($newSecret.Length); not echoed)" -ForegroundColor Green
+Write-Host ""
+
+# Optional: validate tenant id if the operator's deployment-settings.tenant.id is set
+if ($tenantIdMatch.Success) {
+    $observedTenantId = $tenantIdMatch.Groups['id'].Value
+    $declaredTenantId = $settings.tenant.id
+    if ($declaredTenantId -and $declaredTenantId -ne '<set-me: tenant GUID>' -and $observedTenantId -ne $declaredTenantId) {
+        Write-Warning "Setup-ServicePrincipal: pac reported tenant '$observedTenantId' but deployment-settings.tenant.id is '$declaredTenantId'. Continuing, but you may want to update settings."
+    }
+}
+
+# ─── Write back to deployment-settings.json ─────────────────────────────────
+
+Write-Host "[Apply] Writing back to deployment-settings.json..." -ForegroundColor Yellow
+
+# Ensure the ids + secrets sections exist
+if (-not (Test-PSObjectProperty -InputObject $settings -PropertyName 'ids')) {
+    $settings | Add-Member -MemberType NoteProperty -Name 'ids' -Value ([pscustomobject]@{})
+}
+if (-not (Test-PSObjectProperty -InputObject $settings -PropertyName 'secrets')) {
+    $settings | Add-Member -MemberType NoteProperty -Name 'secrets' -Value ([pscustomobject]@{})
+}
+
+# Set / update the two values
+Set-PSObjectProperty -InputObject $settings.ids -PropertyName 'cch_IdEntraAppServicePrincipal' -Value $newAppId
+
+$secretRef = "plain:$newSecret"
+Set-PSObjectProperty -InputObject $settings.secrets -PropertyName 'cch_SecretSPClient' -Value $secretRef
+
+# Write back. Use Depth 10 to preserve nested objects.
+$settingsPath = if ($DeploymentSettingsPath) { $DeploymentSettingsPath } elseif ($env:DEPLOYMENT_SETTINGS_PATH) { $env:DEPLOYMENT_SETTINGS_PATH } else { Join-Path (Get-RepoRoot) 'scripts/deployment-settings.json' }
+
+# Validate the resulting secret reference parses cleanly
+$parsed = Test-SecretReference $secretRef
+if ($parsed.Mode -ne 'plain') {
+    Write-Error "Setup-ServicePrincipal: unexpected SecretRef shape after wrap: $($parsed | ConvertTo-Json -Compress). Aborting write-back."
+    exit 2
+}
+
+$settings | ConvertTo-Json -Depth 10 | Set-Content -Path $settingsPath -Encoding utf8
+
+Write-Host "[Apply] Wrote: $settingsPath" -ForegroundColor Green
+Write-Host "  ids.cch_IdEntraAppServicePrincipal = $newAppId" -ForegroundColor Green
+Write-Host "  secrets.cch_SecretSPClient         = plain:<redacted; length $($newSecret.Length)>" -ForegroundColor Green
+Write-Host ""
+
+# ─── Reminder for follow-up steps ───────────────────────────────────────────
+
+Write-Host "Next steps for the operator:" -ForegroundColor Cyan
+Write-Host "  1. Run 'pac admin list-service-principal --environment $($settings.environment.url)' to verify." -ForegroundColor DarkGray
+Write-Host "  2. After Dataverse-Engineer issue #5 (Phase 1) lands the bespoke 'ServicePrincipal' role," -ForegroundColor DarkGray
+Write-Host "     re-run this script with -SecurityRole 'ServicePrincipal' to downgrade from SysAdmin." -ForegroundColor DarkGray
+Write-Host "  3. install.ps1 will separately handle the Pages Entra app reg + Graph admin consent" -ForegroundColor DarkGray
+Write-Host "     for ChannelMessage.Send (operator confirms inline at install time)." -ForegroundColor DarkGray
+Write-Host ""
+
+exit 0

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -170,6 +170,44 @@ function Get-Section_EnvVars {
         -Title '[NotImplemented] Deployed Dataverse env-var check' `
         -Detail 'Lands in Phase 1+ once a target env exists.'
 
+    # Entra app reg checks (per Topic 11 section A3 / Lead PR #2 / Sitting 4g):
+    # We can already verify deployment-settings.json *contains* the two Entra app IDs
+    # without needing tenant access. Doctor stays read-only.
+    $settingsPath = Join-Path $repoRoot 'scripts/deployment-settings.json'
+    if (Test-Path $settingsPath) {
+        try {
+            $s = Get-Content $settingsPath -Raw | ConvertFrom-Json
+            $hasIds = ($s.PSObject.Properties.Name -contains 'ids') -and $s.ids -and (@($s.ids.PSObject.Properties).Count -gt 0)
+            foreach ($idName in @('cch_IdEntraAppServicePrincipal', 'cch_IdEntraAppPagesAuth')) {
+                $present = $false
+                $value = $null
+                if ($hasIds) {
+                    $props = @($s.ids.PSObject.Properties)
+                    if ($props.Name -contains $idName) {
+                        $value = $s.ids.$idName
+                        $present = ($null -ne $value -and $value -ne '')
+                    }
+                }
+                if ($present) {
+                    $findings += New-Finding -Id "envvars.entra.$idName.present" -Severity 'pass' `
+                        -Title "$idName populated in deployment-settings.json"
+                } else {
+                    $findings += New-Finding -Id "envvars.entra.$idName.missing" -Severity 'info' `
+                        -Title "$idName not yet populated" `
+                        -Detail 'Run scripts/Setup-ServicePrincipal.ps1 (for SP) or scripts/install.ps1 -Mode install (for Pages auth) to provision.'
+                }
+            }
+        } catch {
+            $findings += New-Finding -Id 'envvars.settings.parse-fail' -Severity 'warn' `
+                -Title 'deployment-settings.json failed to parse for Entra-id check' `
+                -Detail $_.Exception.Message
+        }
+    } else {
+        $findings += New-Finding -Id 'envvars.settings.missing' -Severity 'info' `
+            -Title 'deployment-settings.json not present' `
+            -Detail 'Operator copies scripts/deployment-settings.json.template before running install.ps1.'
+    }
+
     $findings
 }
 
@@ -304,11 +342,11 @@ if ($Json) {
     $result | ConvertTo-Json -Depth 10 -Compress
 } else {
     Write-Host ""
-    Write-Host "─── doctor.ps1 — read-only health check ───────────────────────────────" -ForegroundColor Cyan
+    Write-Host "--- doctor.ps1 - read-only health check ------------------------------" -ForegroundColor Cyan
     $vignetteLabel = if ($Vignette) { " [$Vignette]" } else { '' }
     Write-Host "  Run:    $runId" -ForegroundColor DarkGray
     Write-Host "  Mode:   $Mode$vignetteLabel" -ForegroundColor DarkGray
-    Write-Host "────────────────────────────────────────────────────────────────────────" -ForegroundColor Cyan
+    Write-Host "----------------------------------------------------------------------" -ForegroundColor Cyan
 
     foreach ($sectionResult in $result.sections) {
         Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -128,16 +128,16 @@ if (-not $DeploymentSettingsPath) {
 }
 
 # ─── Banner ─────────────────────────────────────────────────────────────────
-$bannerMode = if ($Apply) { '[APPLY]' } else { '[WHATIF — no mutation; pass -Apply to actually run]' }
+$bannerMode = if ($Apply) { '[APPLY]' } else { '[WHATIF -- no mutation; pass -Apply to actually run]' }
 Write-Host ""
-Write-Host "─── HLS Power Platform Demo — install.ps1 ─────────────────────────────" -ForegroundColor Cyan
+Write-Host "--- HLS Power Platform Demo - install.ps1 ----------------------------" -ForegroundColor Cyan
 Write-Host "  Mode:                      $Mode"
 Write-Host "  Deployment settings:       $DeploymentSettingsPath"
 Write-Host "  Apply:                     $bannerMode"
 Write-Host "  Non-interactive:           $($NonInteractive.IsPresent)"
 Write-Host "  Log level:                 $LogLevel"
 Write-Host "  Repo root:                 $repoRoot"
-Write-Host "────────────────────────────────────────────────────────────────────────" -ForegroundColor Cyan
+Write-Host "----------------------------------------------------------------------" -ForegroundColor Cyan
 Write-Host ""
 
 # ─── Mode dispatcher ────────────────────────────────────────────────────────
@@ -154,25 +154,80 @@ function Invoke-NotImplemented {
 
 switch ($Mode) {
     'install' {
-        # TODO Lead (Sitting 4g+):
-        #   1. Validate deployment-settings.json against deployment-settings.schema.json
-        #   2. Prompt for missing required env vars (unless -NonInteractive)
-        #   3. Provision Entra app regs (cch_IdEntraAppPagesAuth + cch_IdEntraAppServicePrincipal)
-        #      — see Setup-ServicePrincipal.ps1 (Sitting 4g per Topic 11 §A3)
-        #   4. Provision SharePoint site + Continuum Knowledge library + 4 subfolders
-        #   5. Provision Teams team + 4 channels (Quality, Leadership, Field, Enablement)
-        #      + add SP to team membership; prompt for Graph admin consent for ChannelMessage.Send
-        #   6. Import solution (pac solution import) — empty in Phase 0; tables land Phase 1
-        #   7. Populate Dataverse env vars from settings + EnvVarManifest defaults
-        #   8. Run baseline migration (0001_baseline.ps1) — stamps cch_DeploymentVersion
-        #   9. Insert seed data (via data/seed.ts when Phase 1 ships)
-        #  10. Emit governance scripts (scripts/governance/*.ps1) per Topic 5; print paths.
-        #      Do NOT run them.
-        #  11. Run smoke suite (scripts/lib/Smoke.ps1) — Sitting 5+
-        #  12. Print pre-demo checklist + Demo Health URL
-        Invoke-NotImplemented `
-            -What "install: full first-time provision" `
-            -Topic "Topic 4 (env vars), Topic 5 (governance), Topic 11 §A3 (Entra sequencing)"
+        # Per Topic 11 section A3 (Lead PR #2 sequencing), Sitting 4g implements
+        # steps 1–3 of the install pipeline (validate + provision Entra apps).
+        # Steps 4–12 remain TODO; they're called out below as labeled stubs so the
+        # full pipeline shape is visible even before each step is filled in.
+
+        Write-Host "[install] Step 1/12: validate deployment-settings.json shape" -ForegroundColor Cyan
+        # Read-DeploymentSettings already validates required top-level keys.
+        # TODO Lead (Sitting 6+): full ajv-cli validation against
+        #   scripts/deployment-settings.schema.json (faster + stricter than the
+        #   manual key check in Read-DeploymentSettings).
+        . (Join-Path $PSScriptRoot 'lib/Governance.ps1')
+        $settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+        Write-Host "  pass: settings parsed; targeting '$($settings.environment.name)'" -ForegroundColor Green
+        Write-Host ""
+
+        Write-Host "[install] Step 2/12: prompt for missing required env vars" -ForegroundColor Cyan
+        # TODO Lead (Sitting 6+): cross-reference scripts/lib/EnvVarManifest.json
+        # 'required' field; for each missing required value, prompt operator
+        # (unless -NonInteractive, in which case fail fast with the list).
+        Write-Host "  [NotImplemented step] env-var prompting" -ForegroundColor Yellow
+        Write-Host "    Will iterate scripts/lib/EnvVarManifest.json 'required' entries." -ForegroundColor DarkGray
+        Write-Host ""
+
+        Write-Host "[install] Step 3/12: provision Entra app registrations" -ForegroundColor Cyan
+        Write-Host "  3a. Service principal (Setup-ServicePrincipal.ps1)" -ForegroundColor DarkCyan
+        if (-not $Apply) {
+            Write-Host "    [whatif] Would invoke: pwsh ./scripts/Setup-ServicePrincipal.ps1 $(if ($NonInteractive) { '-NonInteractive ' })-Apply" -ForegroundColor DarkGray
+            Write-Host "    Run with -Apply to actually provision." -ForegroundColor DarkGray
+        } else {
+            Write-Host "    [Apply] Invoking Setup-ServicePrincipal.ps1 -Apply..." -ForegroundColor Yellow
+            $spScript = Join-Path $PSScriptRoot 'Setup-ServicePrincipal.ps1'
+            & $spScript -Apply -DeploymentSettingsPath $DeploymentSettingsPath
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "[install] Step 3a failed (Setup-ServicePrincipal exit $LASTEXITCODE). Aborting."
+                exit 2
+            }
+            # Re-read settings since Setup-ServicePrincipal.ps1 wrote back
+            $settings = Read-DeploymentSettings -Path $DeploymentSettingsPath
+            Write-Host "    pass: cch_IdEntraAppServicePrincipal populated" -ForegroundColor Green
+        }
+        Write-Host ""
+
+        Write-Host "  3b. Pages auth Entra app (scripts/lib/EntraApps.ps1)" -ForegroundColor DarkCyan
+        # Pages app reg needs cch_UrlPagesSite to set the redirect URI.
+        # In a fresh install, that URL doesn't exist yet (Pages site provisions
+        # in step 7+). Two-pass options:
+        #   Option A: provision Pages site FIRST, then Pages app reg using the URL.
+        #   Option B: provision Pages app reg with placeholder, update redirect URI after.
+        # Option A is cleaner; we defer 3b until after Pages site provisioning lands.
+        Write-Host "    [NotImplemented step] Pages auth Entra app reg" -ForegroundColor Yellow
+        Write-Host "    Sequencing: needs cch_UrlPagesSite (step 7+) before redirect URI can be set." -ForegroundColor DarkGray
+        Write-Host "    Lib is ready: . scripts/lib/EntraApps.ps1; New-PagesAuthApp -DisplayName ... -PagesSiteUrl ..." -ForegroundColor DarkGray
+        Write-Host ""
+
+        Write-Host "[install] Steps 4-12: TODO subsequent sittings" -ForegroundColor DarkGray
+        Write-Host "  4. SharePoint site + Continuum Knowledge library + 4 subfolders" -ForegroundColor DarkGray
+        Write-Host "  5. Teams team + 4 channels + add SP + Graph admin consent for ChannelMessage.Send" -ForegroundColor DarkGray
+        Write-Host "  6. Import solution (pac solution import) -- empty in Phase 0; tables land Phase 1" -ForegroundColor DarkGray
+        Write-Host "  7. Populate Dataverse env vars from settings + EnvVarManifest defaults" -ForegroundColor DarkGray
+        Write-Host "     (also: sets cch_UrlPagesSite once Pages activates, then loops back to 3b)" -ForegroundColor DarkGray
+        Write-Host "  8. Run baseline migration (0001_baseline.ps1) -- stamps cch_DeploymentVersion" -ForegroundColor DarkGray
+        Write-Host "  9. Insert seed data (via data/seed.ts when Phase 1 ships)" -ForegroundColor DarkGray
+        Write-Host " 10. Emit governance scripts (scripts/governance/*.ps1); print paths. Do NOT run them." -ForegroundColor DarkGray
+        Write-Host " 11. Run smoke suite (scripts/lib/Smoke.ps1) -- Sitting 5+" -ForegroundColor DarkGray
+        Write-Host " 12. Print pre-demo checklist + Demo Health URL" -ForegroundColor DarkGray
+        Write-Host ""
+
+        if (-not $Apply) {
+            Write-Host "[install] --whatif preview complete. Pass -Apply to actually run step 3a." -ForegroundColor Green
+        } else {
+            Write-Host "[install] Steps 1 + 3a complete. Steps 2 + 3b + 4-12 await subsequent sittings." -ForegroundColor Yellow
+        }
+        # Exit 0 (preview success) regardless of -Apply, since the implemented steps did the right thing.
+        exit 0
     }
 
     'upgrade' {

--- a/scripts/lib/EntraApps.ps1
+++ b/scripts/lib/EntraApps.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+    Entra ID app registration helpers — used by install.ps1 to provision the Power Pages
+    identity provider app reg (cch_IdEntraAppPagesAuth).
+
+.DESCRIPTION
+    Per Topic 11 section A3 sequencing:
+      - Setup-ServicePrincipal.ps1 handles cch_IdEntraAppServicePrincipal (uses pac admin
+        create-service-principal which also creates the Dataverse Application User).
+      - This lib handles cch_IdEntraAppPagesAuth (a separate Entra app reg used as Power
+        Pages identity provider; web-app type with redirect URI to the Pages site).
+
+    The Pages app reg has different shape than the SP app reg:
+      - Web platform with redirect URI = <Pages site URL>/signin-oidc
+      - ID tokens enabled
+      - No Dataverse Application User (Pages users authenticate AS themselves, not as the app)
+      - Confidential client; client secret needed for token exchange
+
+    Uses 'az ad app' (Azure CLI) since pac doesn't expose Entra app reg primitives
+    beyond the SP+ApplicationUser pair.
+
+    Functions exported (via dot-sourcing):
+      - New-PagesAuthApp       Provision the Pages auth app reg (idempotent)
+      - Get-PagesAuthApp       Look up an existing Pages auth app reg by display name
+      - Test-AzCliAvailable    Pre-flight check
+
+.NOTES
+    Owner role: Lead (per scripts/AGENTS.md).
+    Topic refs: Topic 11 section A3 (Lead PR #2 sequencing), Topic 4 (cch_IdEntraAppPagesAuth).
+    Required PowerShell: 7+. Required CLI: az 2.0+ with operator authenticated
+    (az login + tenant scope).
+#>
+
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-AzCliAvailable {
+    <#
+    .SYNOPSIS
+        Returns $true if 'az' is on PATH and the operator has run 'az login'.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+    try {
+        $null = az account show --query id -o tsv 2>$null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-PagesAuthApp {
+    <#
+    .SYNOPSIS
+        Look up an existing Pages auth Entra app reg by display name.
+        Returns $null if not found, or a pscustomobject with appId + displayName + tenantId.
+    #>
+    [CmdletBinding()]
+    [OutputType([psobject])]
+    param(
+        [Parameter(Mandatory)] [string] $DisplayName
+    )
+
+    if (-not (Test-AzCliAvailable)) {
+        throw "Get-PagesAuthApp: az CLI not available or not authenticated. Run 'az login' first."
+    }
+
+    $jsonRaw = az ad app list --display-name $DisplayName --query "[0].{appId:appId, displayName:displayName}" -o json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $jsonRaw -or $jsonRaw -eq 'null') {
+        return $null
+    }
+
+    try {
+        $app = $jsonRaw | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+
+    # Look up tenant id separately
+    $tenantId = az account show --query tenantId -o tsv 2>$null
+
+    return [pscustomobject]@{
+        appId       = $app.appId
+        displayName = $app.displayName
+        tenantId    = $tenantId
+    }
+}
+
+function New-PagesAuthApp {
+    <#
+    .SYNOPSIS
+        Provision the Power Pages identity-provider Entra app reg. Idempotent.
+
+    .DESCRIPTION
+        If an app with the same DisplayName already exists, returns its details
+        unchanged (no secret rotation, no redirect-URI overwrite).
+
+        On fresh provision, creates:
+          - Web platform with redirect URI: <PagesSiteUrl>/signin-oidc
+          - ID tokens enabled (oauth2AllowIdTokenImplicitFlow)
+          - One client secret (1-year expiry)
+
+        Returns:
+          [pscustomobject] @{ appId; displayName; tenantId; clientSecret (only on fresh
+          provision); created (bool) }
+
+    .PARAMETER DisplayName
+        Entra app reg display name. Convention: '<env-slug>-pages-auth'.
+
+    .PARAMETER PagesSiteUrl
+        The deployed Power Pages site URL. The redirect URI is appended as /signin-oidc.
+        Per Topic 4 cch_UrlPagesSite spec: must start with https; cannot contain localhost.
+    #>
+    [CmdletBinding()]
+    [OutputType([psobject])]
+    param(
+        [Parameter(Mandatory)] [string] $DisplayName,
+        [Parameter(Mandatory)] [string] $PagesSiteUrl
+    )
+
+    if (-not (Test-AzCliAvailable)) {
+        throw "New-PagesAuthApp: az CLI not available or not authenticated. Run 'az login' first."
+    }
+
+    if ($PagesSiteUrl -notmatch '^https://') {
+        throw "New-PagesAuthApp: PagesSiteUrl must start with https:// (got '$PagesSiteUrl'). Per Topic 4 runtime independence."
+    }
+    if ($PagesSiteUrl -match 'localhost|127\.0\.0\.1') {
+        throw "New-PagesAuthApp: PagesSiteUrl cannot contain localhost or 127.0.0.1 (got '$PagesSiteUrl'). Per locked runtime independence."
+    }
+
+    # Idempotency: if app exists, return as-is
+    $existing = Get-PagesAuthApp -DisplayName $DisplayName
+    if ($existing) {
+        return [pscustomobject]@{
+            appId        = $existing.appId
+            displayName  = $existing.displayName
+            tenantId     = $existing.tenantId
+            clientSecret = $null  # we don't rotate on idempotent return
+            created      = $false
+        }
+    }
+
+    # Compose redirect URI
+    $redirectUri = $PagesSiteUrl.TrimEnd('/') + '/signin-oidc'
+
+    # Create the app reg
+    $createOutput = az ad app create `
+        --display-name $DisplayName `
+        --sign-in-audience AzureADMyOrg `
+        --web-redirect-uris $redirectUri `
+        --enable-id-token-issuance true `
+        -o json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "New-PagesAuthApp: az ad app create failed: $createOutput"
+    }
+
+    $newApp = $createOutput | ConvertFrom-Json
+
+    # Generate a client secret (1-year expiry)
+    $secretOutput = az ad app credential reset `
+        --id $newApp.appId `
+        --display-name "$DisplayName-secret" `
+        --years 1 `
+        -o json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "New-PagesAuthApp: az ad app credential reset failed: $secretOutput"
+    }
+
+    $cred = $secretOutput | ConvertFrom-Json
+    $tenantId = az account show --query tenantId -o tsv
+
+    return [pscustomobject]@{
+        appId        = $newApp.appId
+        displayName  = $newApp.displayName
+        tenantId     = $tenantId
+        clientSecret = $cred.password
+        created      = $true
+    }
+}

--- a/scripts/lib/Governance.ps1
+++ b/scripts/lib/Governance.ps1
@@ -25,6 +25,45 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+function Test-PSObjectProperty {
+    <#
+    .SYNOPSIS
+        StrictMode-safe check for whether a PSCustomObject has a named property.
+
+        Why this exists: under Set-StrictMode -Version Latest, accessing
+        $obj.PSObject.Properties.Name on an empty PSCustomObject throws
+        ("The property 'Name' cannot be found on this object"). This helper
+        wraps the gotcha so callers don't repeat the workaround.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)] [psobject] $InputObject,
+        [Parameter(Mandatory)] [string]   $PropertyName
+    )
+    $properties = @($InputObject.PSObject.Properties)
+    if ($properties.Count -eq 0) { return $false }
+    return ($properties.Name -contains $PropertyName)
+}
+
+function Set-PSObjectProperty {
+    <#
+    .SYNOPSIS
+        StrictMode-safe upsert of a PSCustomObject property. Adds if missing, sets if present.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [psobject] $InputObject,
+        [Parameter(Mandatory)] [string]   $PropertyName,
+        [Parameter(Mandatory)] [AllowNull()] $Value
+    )
+    if (Test-PSObjectProperty -InputObject $InputObject -PropertyName $PropertyName) {
+        $InputObject.$PropertyName = $Value
+    } else {
+        $InputObject | Add-Member -MemberType NoteProperty -Name $PropertyName -Value $Value
+    }
+}
+
 function Get-RepoRoot {
     [CmdletBinding()]
     [OutputType([string])]
@@ -128,6 +167,10 @@ function Invoke-GovernanceNotImplemented {
     .SYNOPSIS
         Standard skeleton exit per Topic 11 section C3 -- Phase-0 governance scripts emit
         the planned action plan (preview), then exit 99.
+
+        Use this for scripts where the implementation is not yet written. For scripts
+        that ARE implemented but are running in --whatif preview mode, use
+        Show-GovernancePreview instead (exits 0).
     #>
     [CmdletBinding()]
     param(
@@ -158,4 +201,33 @@ function Invoke-GovernanceNotImplemented {
     Write-Host "  Real implementation lands in a subsequent sitting." -ForegroundColor DarkGray
     Write-Host "  Exit code 99." -ForegroundColor DarkGray
     exit 99
+}
+
+function Show-GovernancePreview {
+    <#
+    .SYNOPSIS
+        Prints the planned actions for a real (implemented) script running in --whatif
+        mode, then exits 0. Use when the script body actually exists but the operator
+        hasn't passed -Apply.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $ScriptName,
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
+        [string[]] $PlannedActions
+    )
+    Write-Host "Planned actions (--whatif preview; pass -Apply to actually run):" -ForegroundColor DarkCyan
+    foreach ($action in $PlannedActions) {
+        if ([string]::IsNullOrWhiteSpace($action)) {
+            Write-Host ""
+        } else {
+            Write-Host "  $action" -ForegroundColor DarkGray
+        }
+    }
+    Write-Host ""
+    Write-Host "[whatif] '$ScriptName' preview complete. No mutations performed." -ForegroundColor Green
+    Write-Host "  Exit code 0." -ForegroundColor DarkGray
+    exit 0
 }


### PR DESCRIPTION
## Summary

Sitting 4g (Lead PR #2 per Topic 11 §A3). **Closes #4.**

### New: scripts/Setup-ServicePrincipal.ps1 (real, not skeleton)

Wraps `pac admin create-service-principal`. Idempotent. --whatif default. Writes back `cch_IdEntraAppServicePrincipal` + `cch_SecretSPClient` (as `plain:<value>` per Topic 4 SecretRef). Parses pac output format **verified against pac 2.6.4 actual output 2026-04-29**.

### New: scripts/lib/EntraApps.ps1

Helpers for the **separate** Pages-auth Entra app reg (`cch_IdEntraAppPagesAuth`). Uses `az ad app create` since `pac` doesn't expose plain Entra-app primitives. Test-AzCliAvailable + Get-PagesAuthApp + New-PagesAuthApp. 4/4 inline smoke tests passed.

### Refactor: scripts/lib/Governance.ps1

- New StrictMode-safe helpers: `Test-PSObjectProperty` + `Set-PSObjectProperty` (workaround for `$obj.PSObject.Properties.Name` throwing on empty PSCustomObject under StrictMode).
- New `Show-GovernancePreview` — exits 0 for real-scripts-in-whatif (distinct from `Invoke-GovernanceNotImplemented` which exits 99 for skeletons).

### Refactor: scripts/install.ps1 'install' branch

12-step pipeline now visible. Steps 1 + 3a real; step 3b sequenced behind step 7+ (Pages app reg needs `cch_UrlPagesSite` for redirect URI); steps 2, 3b, 4–12 labeled stubs with Topic refs.

### Doctor extension

`[EnvVars]` section gains presence checks for both Entra-app IDs (reads deployment-settings.json; no tenant calls).

## Affected role(s)

- [x] Lead (primary)
- [x] Tester (doctor extension)

## Affected phase(s)

- [x] Phase 0

## Decisions

- [x] No new locked decisions. Two lessons learned in commit message:
  - PSObject.Properties.Name throws under StrictMode on empty objects → factored into Test-/Set-PSObjectProperty helpers
  - pac admin create-service-principal output format uses `Tenant Id`/`Application Id` (whitespace separator), not `Tenant ID:`/`Application ID:`

## Checks

- [x] Tests added or extended where applicable — 4/4 EntraApps smoke tests + parser verified against real pac output
- [x] No secrets committed
- [x] `--whatif` default
- [x] Branch matches `feature/p<N>-<name>`

## Notes for reviewer

⚠️ **Author-side incident (no merge impact, captured for posterity):** During parser-format verification I ran `pac admin create-service-principal` with no args, expecting it to print usage. It does NOT — it executes against the default-authenticated env and provisions a real SP. One Entra app reg + one Dataverse Application User were created in the author's personal Dev tenant. Cleaned up via `az ad app delete`; the leaked secret is now invalid. Confirms our `--whatif` default in `Setup-ServicePrincipal.ps1` is essential — `pac` itself has no preview mode.

Per the question I asked the user, `-Apply` of `Setup-ServicePrincipal.ps1` is **operator-tested manually** when wired to a real env, not in CI.