### PR TITLE
docs(p1): preserve branches after squash-merge as educational archive

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ docs/                            demo-script · personas · architecture · gove
 - **Solution name:** `ContinuumHealthDemo`
 - **Web roles:** `AnonymousPatient`, `AuthenticatedPatient`, `AuthenticatedHCP`
 - **Security roles:** `PatientPortal`, `HCPPortal`, `FieldRep`, `QualityAnalyst`
-- **Branch model:** trunk-based on `main`; short-lived `feature/p<N>-<name>` branches (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case). Tier-1 lints the pattern `^feature/p[0-6]-[a-z0-9-]+$` as a warning.
+- **Branch model:** trunk-based on `main`; short-lived `feature/p<N>-<name>` branches (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case). Tier-1 lints the pattern `^feature/p[0-6]-[a-z0-9-]+$` as a warning. **After squash-merge, do NOT delete the branch** — branches are preserved as an educational archive showing how each PR was authored and iterated. (Branches deleted before this convention was set are reconstructed under `archive/pr<NN>-<name>`.)
 - **Commits:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
 - **Code style:** Prettier + ESLint defaults; 2-space indent; LF line endings
 

--- a/.squad/charter.md
+++ b/.squad/charter.md
@@ -68,7 +68,7 @@ For artifacts that don't have a clean single-role owner. Per Topic 10B + Topic 1
 3. **Synthetic data only.** Faker `en_US`. Banner every demo screen.
 4. **Confirm before destructive Power Platform operations.** Even in `--yolo` mode.
 5. **Document every non-trivial decision** in `.squad/decisions.md` via the inbox pattern (Scribe merges).
-6. **Branching:** `feature/p<N>-<name>` (Tier-1 lints regex `^feature/p[0-6]-[a-z0-9-]+$`).
+6. **Branching:** `feature/p<N>-<name>` (Tier-1 lints regex `^feature/p[0-6]-[a-z0-9-]+$`). After squash-merge, **do NOT delete the branch** — branches are preserved as an educational archive of how each PR was authored. Pre-convention deleted branches are reconstructed under `archive/pr<NN>-<name>`.
 7. **Never commit secrets.** `.env.local` only.
 8. **Stay in your lane.** Cross-component changes require Lead handoff.
 9. **Tests as you go.** Tester is embedded; every role co-authors tests as part of feature work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ Full per-role charter (Mission · Owns · Doesn't own · Hand-offs · Definition
    (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case; e.g.
    `feature/p0-tier1-workflow`, `feature/p2-pages-shell`). PRs go to `main`.
    Squash-merge. Tier-1 lints the branch pattern as a warning.
+   **Branch preservation:** after squash-merge, **do NOT delete the branch**
+   (no `--delete-branch` flag on `gh pr merge`). Branches serve as an educational
+   archive showing how each PR was authored + iterated. Branches deleted before
+   this convention was set are reconstructed under `archive/pr<NN>-<name>` and
+   pushed to `origin`.
 
 8. **Never commit secrets.** Use `.env.local` (template `.env.example`).
 


### PR DESCRIPTION
## Summary

Adds a 'do not delete branch after squash-merge' convention to the 3 places that documented the branching rule. Out of band: 6 already-deleted Phase-0/1 branches were reconstructed from their original tip SHAs and pushed as `archive/pr<NN>-<name>`.

## Why

The branches show how each PR was authored + iterated. Especially valuable for the agent-authored PR #16 (two empty-commit re-triggers + CHANGES_REQUESTED → address-all-4 cycle). Squash-merge collapses that history on main; preserving the branch keeps the original commit graph walkable without spelunking PR pages.

## Affected role(s)

- [x] Lead (convention update + branch reconstruction)
- [x] Scribe (charter / agents.md edits)

## Affected phase(s)

- [x] Phase 1

## Decisions

- [x] No new locked decisions; this is a refinement of locked branching convention.

## Checks

- [x] No code changes (docs only)
- [x] No secrets committed
- [x] Branch matches `feature/p<N>-<name>`

## Notes for reviewer

After merge, **do not pass `--delete-branch`**. The new convention applies starting with this PR.