### PR TITLE
docs(p1): revert branch-preservation convention; PRs preserve the educational record

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ docs/                            demo-script · personas · architecture · gove
 - **Solution name:** `ContinuumHealthDemo`
 - **Web roles:** `AnonymousPatient`, `AuthenticatedPatient`, `AuthenticatedHCP`
 - **Security roles:** `PatientPortal`, `HCPPortal`, `FieldRep`, `QualityAnalyst`
-- **Branch model:** trunk-based on `main`; short-lived `feature/p<N>-<name>` branches (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case). Tier-1 lints the pattern `^feature/p[0-6]-[a-z0-9-]+$` as a warning. **After squash-merge, do NOT delete the branch** — branches are preserved as an educational archive showing how each PR was authored and iterated. (Branches deleted before this convention was set are reconstructed under `archive/pr<NN>-<name>`.)
+- **Branch model:** trunk-based on `main`; short-lived `feature/p<N>-<name>` branches (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case). Tier-1 lints the pattern `^feature/p[0-6]-[a-z0-9-]+$` as a warning. **After squash-merge, delete the branch** (`gh pr merge --squash --delete-branch`). PR conversation + inline reviews + per-commit history are preserved on the PR page regardless.
 - **Commits:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
 - **Code style:** Prettier + ESLint defaults; 2-space indent; LF line endings
 

--- a/.squad/charter.md
+++ b/.squad/charter.md
@@ -68,7 +68,7 @@ For artifacts that don't have a clean single-role owner. Per Topic 10B + Topic 1
 3. **Synthetic data only.** Faker `en_US`. Banner every demo screen.
 4. **Confirm before destructive Power Platform operations.** Even in `--yolo` mode.
 5. **Document every non-trivial decision** in `.squad/decisions.md` via the inbox pattern (Scribe merges).
-6. **Branching:** `feature/p<N>-<name>` (Tier-1 lints regex `^feature/p[0-6]-[a-z0-9-]+$`). After squash-merge, **do NOT delete the branch** — branches are preserved as an educational archive of how each PR was authored. Pre-convention deleted branches are reconstructed under `archive/pr<NN>-<name>`.
+6. **Branching:** `feature/p<N>-<name>` (Tier-1 lints regex `^feature/p[0-6]-[a-z0-9-]+$`). After squash-merge, **delete the branch** (`gh pr merge --squash --delete-branch`). PR conversation + inline reviews + per-commit history are preserved on the PR page; branch refs add no educational value.
 7. **Never commit secrets.** `.env.local` only.
 8. **Stay in your lane.** Cross-component changes require Lead handoff.
 9. **Tests as you go.** Tester is embedded; every role co-authors tests as part of feature work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,9 @@ Full per-role charter (Mission · Owns · Doesn't own · Hand-offs · Definition
    (where `<N>` is the numeric phase 0–6 and `<name>` is kebab-case; e.g.
    `feature/p0-tier1-workflow`, `feature/p2-pages-shell`). PRs go to `main`.
    Squash-merge. Tier-1 lints the branch pattern as a warning.
-   **Branch preservation:** after squash-merge, **do NOT delete the branch**
-   (no `--delete-branch` flag on `gh pr merge`). Branches serve as an educational
-   archive showing how each PR was authored + iterated. Branches deleted before
-   this convention was set are reconstructed under `archive/pr<NN>-<name>` and
-   pushed to `origin`.
+   **After squash-merge, delete the branch** (`gh pr merge --squash --delete-branch`).
+   The PR conversation, inline reviews, and per-commit history are preserved on the
+   PR page itself; branch refs add no educational value beyond what the PR shows.
 
 8. **Never commit secrets.** Use `.env.local` (template `.env.example`).
 


### PR DESCRIPTION
## Summary

Reverts PR #18's convention. Restores the original 'delete branch after squash-merge' behavior across all 3 docs (AGENTS.md, copilot-instructions.md, .squad/charter.md).

## Why

PR #18 was solving a problem that doesn't exist. The PR page itself preserves everything that matters for an educational record:

- Conversation thread (review comments, agent responses, change requests)
- Inline reviews on diffs (the request-changes line annotations)
- Per-commit history of the branch (the PR's 'Commits' tab)
- Squashed merge commit on main with full body

Deleting the branch removes only the branch *ref*, not any of the above.

## Affected role(s)

- [x] Lead

## Affected phase(s)

- [x] Phase 1

## Decisions

- [x] No new locked decisions; this is a refinement that reverts an unnecessary one.

## Checks

- [x] No code changes (docs only)
- [x] No secrets committed
- [x] Branch matches `feature/p<N>-<name>`

## Notes for reviewer

After merge: I'll delete the 6 `archive/pr<NN>-*` branches reconstructed overnight (now redundant since the PR pages preserve everything they were supposed to). Going forward, all PR merges use `--delete-branch`.